### PR TITLE
Add dedicated residential pricing pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-//
+# SoksLine Proxy Store
+
+Next.js (App Router) демо витрина для магазина прокси.
+
+## Скрипты
+
+```bash
+npm install       # установка зависимостей
+npm run dev       # запуск development-сервера
+npm run lint      # проверка ESLint
+npm run build     # production-сборка
+npm test          # unit-тесты Vitest
+```
+
+## Переменные окружения
+
+- `NEXT_PUBLIC_BOT_URL` — ссылка на Telegram-бот, которая будет открываться из CTA на главной странице. По умолчанию используется заглушка `https://t.me/your_proxy_bot`.

--- a/__tests__/tabs.test.tsx
+++ b/__tests__/tabs.test.tsx
@@ -1,20 +1,29 @@
-﻿import { render, screen } from "@testing-library/react";
+import React from "react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import TopProductsTabs from "../components/TopProductsTabs";
 
-test("переключение вкладок меняет активную", async () => {
+test("переключение вкладок меняет активную и контент", async () => {
   render(<TopProductsTabs />);
   const user = userEvent.setup();
 
-  const tabs = screen.getAllByRole("tab"); // ожидаем 3 штуки
+  const tablist = screen.getByRole("tablist", { name: /Категории продуктов/i });
+  const tabs = within(tablist).getAllByRole("tab");
   expect(tabs).toHaveLength(3);
 
-  // 0 — ISP, 1 — IPv6, 2 — Rotating
   expect(tabs[0]).toHaveAttribute("aria-selected", "true");
+  const initialPanel = screen.getByRole("tabpanel");
+  expect(within(initialPanel).getByText("US / EU (shared pool)")).toBeInTheDocument();
 
   await user.click(tabs[1]);
+  expect(tabs[0]).toHaveAttribute("aria-selected", "false");
   expect(tabs[1]).toHaveAttribute("aria-selected", "true");
+  const ipv6Panel = screen.getByRole("tabpanel");
+  expect(within(ipv6Panel).getByText("Global IPv6 pool")).toBeInTheDocument();
 
   await user.click(tabs[2]);
+  expect(tabs[1]).toHaveAttribute("aria-selected", "false");
   expect(tabs[2]).toHaveAttribute("aria-selected", "true");
+  const rotatingPanel = screen.getByRole("tabpanel");
+  expect(within(rotatingPanel).getByText("Standard rotation")).toBeInTheDocument();
 });

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,14 @@
-﻿export const metadata = { title: "SoksLine", description: "Proxy store" };
+import HeaderNav from "../components/HeaderNav";
+
+export const metadata = { title: "SoksLine", description: "Proxy store" };
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ru">
-      <body style={{ fontFamily: "system-ui, sans-serif", margin: 0 }}>{children}</body>
+      <body style={{ fontFamily: "system-ui, sans-serif", margin: 0, backgroundColor: "#0b1220" }}>
+        <HeaderNav />
+        {children}
+      </body>
     </html>
   );
 }

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -1,0 +1,270 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  background: #0b1220;
+  min-height: 100vh;
+  padding-top: clamp(4.5rem, 8vw, 5.25rem);
+  scroll-padding-top: clamp(4.5rem, 8vw, 5.25rem);
+}
+
+.section {
+  padding: clamp(3rem, 6vw, 5.5rem) 0;
+}
+
+.sectionInner {
+  width: min(100%, 1120px);
+  margin: 0 auto;
+  padding: 0 clamp(1.5rem, 6vw, 5.5rem);
+  box-sizing: border-box;
+}
+
+.hero {
+  background: linear-gradient(135deg, #0f172a 0%, #17233d 55%, #111927 100%);
+  color: #f8fafc;
+  text-align: center;
+}
+
+.heroInner {
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+  justify-items: center;
+}
+
+.heroEyebrow {
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.heroContent {
+  display: grid;
+  gap: clamp(1.25rem, 2.5vw, 1.9rem);
+  max-width: 52rem;
+}
+
+.heroTitle {
+  font-size: clamp(2.4rem, 6vw, 3.6rem);
+  line-height: 1.1;
+  margin: 0;
+  font-weight: 700;
+}
+
+.heroSubtitle {
+  margin: 0;
+  font-size: clamp(1.1rem, 2vw, 1.3rem);
+  line-height: 1.55;
+  color: rgba(226, 232, 240, 0.78);
+}
+
+.media {
+  background: linear-gradient(135deg, #dbeafe 0%, #ede9fe 60%, #f8fafc 100%);
+  color: #3730a3;
+}
+
+.mediaInner {
+  display: grid;
+  place-items: center;
+  min-height: clamp(14rem, 35vw, 18rem);
+  text-align: center;
+}
+
+.mediaLabel {
+  font-size: clamp(1rem, 2vw, 1.2rem);
+  font-weight: 500;
+  opacity: 0.85;
+}
+
+.sectionHeader {
+  display: grid;
+  gap: 0.5rem;
+  max-width: 38rem;
+}
+
+.sectionTitle {
+  margin: 0;
+  font-size: clamp(1.75rem, 4vw, 2.6rem);
+  font-weight: 700;
+  color: #0b1b38;
+}
+
+.sectionDescription {
+  margin: 0;
+  color: #475569;
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+
+.advantages {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95) 0%, #eff6ff 100%);
+}
+
+.advantagesInner {
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2.4rem);
+}
+
+.showcase {
+  background: linear-gradient(135deg, #f8fafc 0%, #e0f2fe 45%, #e2e8f0 100%);
+}
+
+.showcaseInner {
+  display: grid;
+  gap: clamp(1.8rem, 3vw, 2.6rem);
+}
+
+.showcaseGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: clamp(1rem, 2vw, 1.5rem);
+}
+
+.showcaseCard {
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 1.5rem;
+  padding: clamp(1.25rem, 2.5vw, 1.8rem);
+  box-shadow: 0 24px 48px -40px rgba(15, 23, 42, 0.5);
+  display: grid;
+  gap: 1.1rem;
+}
+
+.showcaseCardHeader {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.showcaseCardTitle {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.showcaseCardPrice {
+  font-weight: 600;
+  color: #2563eb;
+  font-size: 0.95rem;
+}
+
+.showcaseList {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.65rem;
+  color: #1f2937;
+  font-size: 0.98rem;
+  line-height: 1.5;
+}
+
+.showcaseFootnotes {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.75rem;
+  font-weight: 600;
+  color: #0f172a;
+  letter-spacing: 0.01em;
+}
+
+.advantagesGrid {
+  display: grid;
+  gap: clamp(1.1rem, 2vw, 1.6rem);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.advantageCard {
+  background: rgba(255, 255, 255, 0.86);
+  border-radius: 1.5rem;
+  padding: clamp(1.1rem, 2.2vw, 1.6rem);
+  box-shadow: 0 24px 48px -42px rgba(15, 23, 42, 0.65);
+  display: grid;
+  gap: 0.5rem;
+}
+
+.advantageTitle {
+  font-size: 1.1rem;
+  margin: 0;
+  font-weight: 600;
+  color: #111827;
+}
+
+.advantageText {
+  margin: 0;
+  color: #4b5563;
+  line-height: 1.5;
+}
+
+.payments {
+  background: linear-gradient(135deg, #0b1220 0%, #172036 100%);
+  color: #f8fafc;
+}
+
+.paymentsInner {
+  display: grid;
+  gap: clamp(1.6rem, 3vw, 2.4rem);
+}
+
+.paymentsHeader {
+  display: grid;
+  gap: 0.5rem;
+  max-width: 38rem;
+}
+
+.paymentsTitle {
+  margin: 0;
+  font-size: clamp(1.75rem, 3.5vw, 2.4rem);
+  font-weight: 700;
+}
+
+.paymentsDescription {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.78);
+  line-height: 1.6;
+}
+
+.paymentsList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.paymentBadge {
+  padding: 0.55rem 1.3rem;
+  border-radius: 999px;
+  background: rgba(248, 250, 252, 0.08);
+  color: #f8fafc;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  backdrop-filter: blur(6px);
+}
+
+@media (max-width: 768px) {
+  .heroContent {
+    gap: 1.1rem;
+  }
+
+  .showcaseFootnotes {
+    gap: 0.75rem 1.25rem;
+  }
+
+  .sectionTitle,
+  .paymentsTitle {
+    font-size: clamp(1.6rem, 5vw, 2.2rem);
+  }
+}
+
+@media (max-width: 480px) {
+  .section {
+    padding: 2.5rem 0;
+  }
+
+  .sectionInner {
+    padding: 0 1.25rem;
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,74 +1,146 @@
-﻿import TopProductsTabs from "../components/TopProductsTabs";
+import TopProductsTabs from "../components/TopProductsTabs";
+import styles from "./page.module.css";
 
-const BOT_URL = process.env.NEXT_PUBLIC_BOT_URL || "https://t.me/your_proxy_bot";
+const ADVANTAGES = [
+  {
+    title: "Скорость без просадок",
+    description: "Чистые пулы и аплинки уровня Tier-1 поддерживают стабильную полосу даже при пиковой нагрузке."
+  },
+  {
+    title: "Глубокая фильтрация",
+    description: "Тонкая настройка по ASN, городу и прокси-типу помогает подбирать доступы точечно."
+  },
+  {
+    title: "Гибкие тарифы",
+    description: "Статика, IPv6 и ротация — комбинируйте форматы и удерживайте расходы под контролем."
+  },
+  {
+    title: "Платёжные сценарии",
+    description: "От криптовалют до карт — подключите удобный метод и автоматизируйте пополнения."
+  }
+];
+
+const PROXY_SHOWCASE = [
+  {
+    title: "Static ISP",
+    price: "от $5.90 / месяц",
+    points: [
+      "Дедикейт IPv4-подключения для долгих сессий",
+      "Выбор гео по городу и ASN"
+    ]
+  },
+  {
+    title: "Static ISP IPv6",
+    price: "от $3.40 / месяц",
+    points: [
+      "IPv6-пулы для масштабных задач",
+      "Лёгкая интеграция через SOCKS5"
+    ]
+  },
+  {
+    title: "Rotating Residential",
+    price: "от $4.80 / GB",
+    points: [
+      "Автообновление IP по расписанию",
+      "Лимиты и сессии через API"
+    ]
+  }
+];
+
+const PROXY_METRICS = ["180+ Proxy Locations", "99.9% Uptime"];
+
+const PAYMENT_METHODS = ["USDT", "BTC", "ETH", "Visa/Mastercard", "SEPA", "СБП"];
 
 export default function Page() {
   return (
-    <main style={{ display: "grid", gap: 32, padding: 32 }}>
-      {/* Хиро — центрированный слоган */}
-      <section style={{ textAlign: "center", padding: "40px 0" }}>
-        <h1 style={{ fontSize: 42, margin: 0 }}>Чистые SOCKS-прокси. Прямая линия скорости.</h1>
-        <p style={{ fontSize: 18, color: "#555" }}>
-          Покупайте и продавайте прокси. Умные фильтры, актуальная аналитика и многое другое.
-        </p>
-        <a
-          href={BOT_URL}
-          target="_blank"
-          rel="noopener"
-          style={{
-            display: "inline-block",
-            marginTop: 14,
-            padding: "12px 18px",
-            borderRadius: 10,
-            background: "#111",
-            color: "#fff",
-            textDecoration: "none",
-            fontWeight: 600
-          }}
-        >
-          Открыть бот
-        </a>
-      </section>
-
-      {/* Изображение под слоганом (плейсхолдер) */}
-      <section style={{ background: "#f4f4f4", borderRadius: 16, height: 240, display: "grid", placeItems: "center" }}>
-        <span style={{ color: "#777" }}>[Тут будет изображение/баннер]</span>
-      </section>
-
-      {/* Блок «3-й скрин» — заглушка со структурой */}
-      <section style={{ background: "#fafafa", borderRadius: 16, padding: 24, border: "1px solid rgba(0,0,0,0.06)" }}>
-        <h2 style={{ marginTop: 0 }}>Почему SoksLine</h2>
-        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit,minmax(200px,1fr))", gap: 16 }}>
-          <div style={{ background: "#fff", borderRadius: 12, padding: 16, border: "1px solid rgba(0,0,0,0.06)" }}>
-            <strong>Скорость</strong>
-            <p style={{ margin: "6px 0 0" }}>Высокая пропускная способность без просадок.</p>
-          </div>
-          <div style={{ background: "#fff", borderRadius: 12, padding: 16, border: "1px solid rgba(0,0,0,0.06)" }}>
-            <strong>Чистота пулов</strong>
-            <p style={{ margin: "6px 0 0" }}>Фильтрация по ASN/стране, низкий спам-рейт.</p>
-          </div>
-          <div style={{ background: "#fff", borderRadius: 12, padding: 16, border: "1px solid rgba(0,0,0,0.06)" }}>
-            <strong>Гибкость тарифов</strong>
-            <p style={{ margin: "6px 0 0" }}>Статика, IPv6 и ротация — под разные задачи.</p>
-          </div>
-          <div style={{ background: "#fff", borderRadius: 12, padding: 16, border: "1px solid rgba(0,0,0,0.06)" }}>
-            <strong>Оплата</strong>
-            <p style={{ margin: "6px 0 0" }}>Крипта и классические методы (отображение ниже).</p>
+    <main className={styles.page}>
+      <section className={`${styles.section} ${styles.hero}`} id="hero">
+        <div className={`${styles.sectionInner} ${styles.heroInner}`}>
+          <span className={styles.heroEyebrow}>SoksLine Proxy Store</span>
+          <div className={styles.heroContent}>
+            <h1 className={styles.heroTitle}>Чистые SOCKS-прокси. Прямая линия скорости.</h1>
+            <p className={styles.heroSubtitle}>
+              Покупайте и продавайте прокси в пару кликов. Умные фильтры, актуальная аналитика и прозрачные тарифы
+              помогают командам запускать инфраструктуру без задержек.
+            </p>
           </div>
         </div>
       </section>
 
-      {/* Табы продуктов */}
+      <section className={`${styles.section} ${styles.media}`} aria-label="Промо-изображение" id="media-preview">
+        <div className={`${styles.sectionInner} ${styles.mediaInner}`}>
+          <span className={styles.mediaLabel}>[Плейсхолдер изображения / видео превью]</span>
+        </div>
+      </section>
+
+      <section className={`${styles.section} ${styles.showcase}`} id="proxy-formats">
+        <div className={`${styles.sectionInner} ${styles.showcaseInner}`}>
+          <div className={styles.sectionHeader}>
+            <h2 className={styles.sectionTitle}>Выберите формат прокси</h2>
+            <p className={styles.sectionDescription}>
+              ISP-статика, IPv6 и ротация — фиксируйте нужные параметры, комбинируйте пулы и управляйте подключениями через
+              единый кабинет.
+            </p>
+          </div>
+          <div className={styles.showcaseGrid}>
+            {PROXY_SHOWCASE.map(item => (
+              <article key={item.title} className={styles.showcaseCard}>
+                <div className={styles.showcaseCardHeader}>
+                  <h3 className={styles.showcaseCardTitle}>{item.title}</h3>
+                  <span className={styles.showcaseCardPrice}>{item.price}</span>
+                </div>
+                <ul className={styles.showcaseList}>
+                  {item.points.map(point => (
+                    <li key={point}>{point}</li>
+                  ))}
+                </ul>
+              </article>
+            ))}
+          </div>
+          <ul className={styles.showcaseFootnotes} aria-label="Ключевые показатели">
+            {PROXY_METRICS.map(metric => (
+              <li key={metric}>{metric}</li>
+            ))}
+          </ul>
+        </div>
+      </section>
+
+      <section className={`${styles.section} ${styles.advantages}`} id="advantages">
+        <div className={`${styles.sectionInner} ${styles.advantagesInner}`}>
+          <div className={styles.sectionHeader}>
+            <h2 className={styles.sectionTitle}>Почему SoksLine</h2>
+            <p className={styles.sectionDescription}>
+              Инструменты для маркетологов, команд по парсингу и продавцов аккаунтов. Фокус на стабильности и контроле.
+            </p>
+          </div>
+          <div className={styles.advantagesGrid}>
+            {ADVANTAGES.map(item => (
+              <article key={item.title} className={styles.advantageCard}>
+                <h3 className={styles.advantageTitle}>{item.title}</h3>
+                <p className={styles.advantageText}>{item.description}</p>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
       <TopProductsTabs />
 
-      {/* Способы оплаты */}
-      <section style={{ background: "#fff", borderRadius: 16, padding: 24, border: "1px solid rgba(0,0,0,0.06)" }}>
-        <h2 style={{ marginTop: 0 }}>Способы оплаты</h2>
-        <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
-          <span style={{ padding: "8px 12px", borderRadius: 8, background: "#f4f4f4" }}>USDT</span>
-          <span style={{ padding: "8px 12px", borderRadius: 8, background: "#f4f4f4" }}>BTC</span>
-          <span style={{ padding: "8px 12px", borderRadius: 8, background: "#f4f4f4" }}>ETH</span>
-          <span style={{ padding: "8px 12px", borderRadius: 8, background: "#f4f4f4" }}>Visa/Mastercard (опц.)</span>
+      <section className={`${styles.section} ${styles.payments}`} id="payments">
+        <div className={`${styles.sectionInner} ${styles.paymentsInner}`}>
+          <div className={styles.paymentsHeader}>
+            <h2 className={styles.paymentsTitle}>Способы оплаты</h2>
+            <p className={styles.paymentsDescription}>
+              Пополняйте баланс удобным способом: автоматические инвойсы, моментальные зачёты и выгрузки для бухгалтерии.
+            </p>
+          </div>
+          <div className={styles.paymentsList}>
+            {PAYMENT_METHODS.map(method => (
+              <span key={method} className={styles.paymentBadge}>
+                {method}
+              </span>
+            ))}
+          </div>
         </div>
       </section>
     </main>

--- a/app/pricing/rotating-residential/page.tsx
+++ b/app/pricing/rotating-residential/page.tsx
@@ -1,0 +1,11 @@
+import PricingTemplate from "../../../components/PricingTemplate";
+import { ROTATING_RESIDENTIAL_PRICING } from "../../../lib/pricing";
+
+export const metadata = {
+  title: "Rotating Residential Proxy Pricing | SoksLine",
+  description: "Discover SoksLine rotating residential proxy packages with global coverage and flexible billing.",
+};
+
+export default function Page() {
+  return <PricingTemplate data={ROTATING_RESIDENTIAL_PRICING} />;
+}

--- a/app/pricing/static-residential-ipv6/page.tsx
+++ b/app/pricing/static-residential-ipv6/page.tsx
@@ -1,0 +1,11 @@
+import PricingTemplate from "../../../components/PricingTemplate";
+import { STATIC_IPV6_PRICING } from "../../../lib/pricing";
+
+export const metadata = {
+  title: "Static Residential IPv6 Proxy Pricing | SoksLine",
+  description: "Choose the right IPv6 static residential proxy package from SoksLine with monthly or yearly billing.",
+};
+
+export default function Page() {
+  return <PricingTemplate data={STATIC_IPV6_PRICING} />;
+}

--- a/app/pricing/static-residential/page.tsx
+++ b/app/pricing/static-residential/page.tsx
@@ -1,0 +1,11 @@
+import PricingTemplate from "../../../components/PricingTemplate";
+import { STATIC_RESIDENTIAL_PRICING } from "../../../lib/pricing";
+
+export const metadata = {
+  title: "Static Residential Proxy Plans | SoksLine",
+  description: "Compare SoksLine static residential proxy pricing tiers with unlimited bandwidth and sticky sessions.",
+};
+
+export default function Page() {
+  return <PricingTemplate data={STATIC_RESIDENTIAL_PRICING} />;
+}

--- a/components/HeaderNav.module.css
+++ b/components/HeaderNav.module.css
@@ -1,0 +1,293 @@
+.wrapper {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: linear-gradient(90deg, rgba(10, 15, 28, 0.95) 0%, rgba(12, 21, 40, 0.95) 100%);
+  backdrop-filter: blur(18px);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.inner {
+  margin: 0 auto;
+  width: min(100%, 1180px);
+  padding: 0.9rem clamp(1.25rem, 4vw, 2.5rem);
+  display: flex;
+  align-items: center;
+  gap: clamp(1rem, 2vw, 2rem);
+  color: #f8fafc;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: inherit;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.brandIcon {
+  display: grid;
+  place-items: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #38bdf8, #2563eb);
+  font-weight: 700;
+  font-size: 1.1rem;
+}
+
+.brandCopy {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.15;
+  font-size: 0.9rem;
+}
+
+.brandCopy strong {
+  font-size: 1rem;
+}
+
+.brandCopy span {
+  color: rgba(226, 232, 240, 0.7);
+  font-weight: 500;
+  font-size: 0.78rem;
+}
+
+.nav {
+  flex: 1;
+}
+
+.navList {
+  display: flex;
+  align-items: center;
+  gap: clamp(0.75rem, 2vw, 1.6rem);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.navItem,
+.navItemSimple {
+  position: relative;
+}
+
+.navTrigger {
+  background: transparent;
+  border: none;
+  color: inherit;
+  font: inherit;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  cursor: pointer;
+  padding: 0.35rem 0;
+  border-radius: 0.75rem;
+  transition: color 0.2s ease;
+}
+
+.navTriggerActive,
+.navTrigger:hover,
+.navTrigger:focus-visible {
+  color: #38bdf8;
+}
+
+.navCaret {
+  font-size: 0.65rem;
+  opacity: 0.7;
+}
+
+.dropdown {
+  position: absolute;
+  top: calc(100% + 0.6rem);
+  left: 0;
+  background: rgba(15, 23, 42, 0.95);
+  color: #e2e8f0;
+  padding: 1.25rem;
+  border-radius: 1.2rem;
+  box-shadow: 0 28px 60px -40px rgba(2, 6, 23, 0.6);
+  display: none;
+  min-width: 16rem;
+  gap: 1.5rem;
+}
+
+.dropdownOpen {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.dropdownColumn {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.dropdownHeading {
+  margin: 0;
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.dropdownList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.dropdownLink {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  text-decoration: none;
+  color: inherit;
+  padding: 0.55rem 0.75rem;
+  border-radius: 0.9rem;
+  background: transparent;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.dropdownLink:hover,
+.dropdownLink:focus-visible {
+  background: rgba(59, 130, 246, 0.15);
+  color: #bae6fd;
+}
+
+.dropdownLabel {
+  font-size: 0.95rem;
+  font-weight: 600;
+  display: block;
+}
+
+.dropdownDescription {
+  display: block;
+  font-size: 0.78rem;
+  color: rgba(203, 213, 225, 0.78);
+  margin-top: 0.25rem;
+}
+
+.dropdownMeta {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #38bdf8;
+}
+
+.navLink {
+  color: rgba(226, 232, 240, 0.8);
+  text-decoration: none;
+  font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0;
+  transition: color 0.2s ease;
+}
+
+.navLink:hover,
+.navLink:focus-visible {
+  color: #38bdf8;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.localeSwitch {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.localeButton,
+.localeButtonMuted {
+  background: none;
+  border: none;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  padding: 0;
+}
+
+.localeButton {
+  font-weight: 600;
+}
+
+.localeButtonMuted {
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.localeDivider {
+  color: rgba(148, 163, 184, 0.4);
+}
+
+.loginButton {
+  padding: 0.55rem 1.1rem;
+  border-radius: 999px;
+  text-decoration: none;
+  font-weight: 600;
+  color: #0b1220;
+  background: #f8fafc;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.loginButton:hover,
+.loginButton:focus-visible {
+  background: #bae6fd;
+  color: #0f172a;
+}
+
+@media (max-width: 960px) {
+  .inner {
+    flex-wrap: wrap;
+    gap: 1rem;
+  }
+
+  .nav {
+    order: 3;
+    width: 100%;
+  }
+
+  .navList {
+    flex-wrap: wrap;
+    row-gap: 0.75rem;
+  }
+
+  .dropdown {
+    position: static;
+    margin-top: 0.4rem;
+    background: rgba(15, 23, 42, 0.85);
+    box-shadow: none;
+  }
+
+  .dropdownOpen {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .inner {
+    justify-content: center;
+  }
+
+  .brandCopy span {
+    display: none;
+  }
+
+  .actions {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .navList {
+    justify-content: center;
+  }
+}

--- a/components/HeaderNav.tsx
+++ b/components/HeaderNav.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import Link from "next/link";
+import { useState, FocusEvent } from "react";
+import styles from "./HeaderNav.module.css";
+
+type DropdownItem = {
+  label: string;
+  description?: string;
+  href: string;
+  meta?: string;
+};
+
+type DropdownSection = {
+  heading?: string;
+  items: DropdownItem[];
+};
+
+type DropdownConfig = {
+  id: string;
+  label: string;
+  sections: DropdownSection[];
+};
+
+const PRODUCT_MENU: DropdownConfig = {
+  id: "products",
+  label: "Продукты",
+  sections: [
+    {
+      items: [
+        {
+          label: "ISP Proxies (DC/ISP)",
+          description: "Доступ к дата-центровым и ISP пуллам для стабильных проектов",
+          href: "#top-products"
+        },
+        {
+          label: "Static Residential",
+          description: "Реальные жилые IP для долгих сессий и антидетект браузеров",
+          href: "#top-products"
+        },
+        {
+          label: "Rotating Residential",
+          description: "Автоматическая ротация IP и гибкие лимиты",
+          href: "#top-products"
+        }
+      ]
+    }
+  ]
+};
+
+const RESOURCES_MENU: DropdownConfig = {
+  id: "resources",
+  label: "Ресурсы",
+  sections: [
+    {
+      heading: "Solutions",
+      items: [
+        { label: "Enterprise Solutions", href: "https://soksline.com/enterprise" },
+        { label: "White Label Reseller", href: "https://soksline.com/reseller" },
+        { label: "Referral Program", href: "https://soksline.com/referral" }
+      ]
+    },
+    {
+      heading: "Developers",
+      items: [{ label: "API Documentation", href: "https://soksline.com/api" }]
+    },
+    {
+      heading: "Resources",
+      items: [
+        { label: "Getting Started", href: "https://soksline.com/getting-started" },
+        { label: "Blog", href: "https://soksline.com/blog" },
+        { label: "Google Chrome Proxy Extension", href: "https://soksline.com/chrome" },
+        { label: "Mozilla Firefox Proxy Add-On", href: "https://soksline.com/firefox" }
+      ]
+    },
+    {
+      heading: "Company",
+      items: [
+        { label: "Careers", href: "https://soksline.com/careers" },
+        { label: "Contact Us", href: "https://soksline.com/contact" }
+      ]
+    }
+  ]
+};
+
+const PRICING_MENU: DropdownConfig = {
+  id: "pricing",
+  label: "Цены",
+  sections: [
+    {
+      heading: "Residential Proxies",
+      items: [
+        {
+          label: "Static Residential Proxies",
+          description: "Real business IPs for long-term use",
+          meta: "Starts at $1.27 / proxy",
+          href: "/pricing/static-residential"
+        },
+        {
+          label: "Static Residential IPv6 Proxies",
+          description: "Trillions ISP Static IPs from USA",
+          meta: "Starts at $0.52 / proxy",
+          href: "/pricing/static-residential-ipv6"
+        },
+        {
+          label: "Rotating Residential Proxies",
+          description: "Ethically sourced residential proxy pool",
+          meta: "Starts at $4.99 / proxy",
+          href: "/pricing/rotating-residential"
+        }
+      ]
+    }
+  ]
+};
+
+const NAV_LINKS = [PRODUCT_MENU, RESOURCES_MENU, PRICING_MENU];
+
+const AUX_LINKS = [
+  { label: "Решения", href: "#advantages" },
+  { label: "Инфоцентр", href: "https://soksline.com/support" }
+];
+
+export default function HeaderNav() {
+  const [openDropdown, setOpenDropdown] = useState<string | null>(null);
+
+  const handleOpen = (id: string | null) => setOpenDropdown(id);
+
+  const handleBlur = (event: FocusEvent<HTMLLIElement>) => {
+    const nextFocus = event.relatedTarget as Node | null;
+    if (!nextFocus || !event.currentTarget.contains(nextFocus)) {
+      setOpenDropdown(null);
+    }
+  };
+
+  return (
+    <header className={styles.wrapper}>
+      <div className={styles.inner}>
+        <Link href="/" className={styles.brand}>
+          <span className={styles.brandIcon} aria-hidden="true">
+            S
+          </span>
+          <span className={styles.brandCopy}>
+            <strong>SoksLine</strong>
+            <span>Proxy Store &amp; Dedicated rotation</span>
+          </span>
+        </Link>
+
+        <nav className={styles.nav} aria-label="Главное меню">
+          <ul className={styles.navList}>
+            {NAV_LINKS.map(menu => (
+              <li
+                key={menu.id}
+                className={styles.navItem}
+                onMouseEnter={() => handleOpen(menu.id)}
+                onMouseLeave={() => handleOpen(null)}
+                onFocus={() => handleOpen(menu.id)}
+                onBlur={handleBlur}
+              >
+                <button
+                  type="button"
+                  className={`${styles.navTrigger} ${openDropdown === menu.id ? styles.navTriggerActive : ""}`}
+                  aria-haspopup="true"
+                  aria-expanded={openDropdown === menu.id}
+                >
+                  {menu.label}
+                  <span aria-hidden="true" className={styles.navCaret}>
+                    ▾
+                  </span>
+                </button>
+
+                <div
+                  className={`${styles.dropdown} ${openDropdown === menu.id ? styles.dropdownOpen : ""}`}
+                  role="menu"
+                >
+                  {menu.sections.map(section => (
+                    <div key={section.heading ?? menu.id} className={styles.dropdownColumn}>
+                      {section.heading && <p className={styles.dropdownHeading}>{section.heading}</p>}
+                      <ul className={styles.dropdownList}>
+                        {section.items.map(item => (
+                          <li key={item.label}>
+                            <Link
+                              href={item.href}
+                              className={styles.dropdownLink}
+                              target={item.href.startsWith("http") ? "_blank" : undefined}
+                              rel={item.href.startsWith("http") ? "noopener" : undefined}
+                            >
+                              <span>
+                                <span className={styles.dropdownLabel}>{item.label}</span>
+                                {item.description && <span className={styles.dropdownDescription}>{item.description}</span>}
+                              </span>
+                              {item.meta && <span className={styles.dropdownMeta}>{item.meta}</span>}
+                            </Link>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  ))}
+                </div>
+              </li>
+            ))}
+            {AUX_LINKS.map(link => (
+              <li key={link.label} className={styles.navItemSimple}>
+                <Link
+                  href={link.href}
+                  className={styles.navLink}
+                  target={link.href.startsWith("http") ? "_blank" : undefined}
+                  rel={link.href.startsWith("http") ? "noopener" : undefined}
+                >
+                  {link.label}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </nav>
+
+        <div className={styles.actions}>
+          <div className={styles.localeSwitch}>
+            <button type="button" className={styles.localeButton} aria-label="Русский">
+              Ru
+            </button>
+            <span className={styles.localeDivider} aria-hidden="true">
+              |
+            </span>
+            <button type="button" className={styles.localeButtonMuted} aria-label="English">
+              En
+            </button>
+          </div>
+          <Link href="https://soksline.com/login" className={styles.loginButton} target="_blank" rel="noopener">
+            Войти
+          </Link>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/components/PricingTemplate.module.css
+++ b/components/PricingTemplate.module.css
@@ -1,0 +1,238 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 4rem;
+  padding-bottom: 6rem;
+}
+
+.hero {
+  background: radial-gradient(120% 120% at 50% 0%, rgba(79, 70, 229, 0.08), rgba(15, 23, 42, 0.05));
+  padding: 6rem 1.5rem 3rem;
+}
+
+.heroInner {
+  margin: 0 auto;
+  max-width: 960px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.heroHighlight {
+  font-size: 0.875rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #6366f1;
+}
+
+.heroTitle {
+  font-size: clamp(2.25rem, 4vw, 3.25rem);
+  line-height: 1.1;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.heroSubtitle {
+  color: #475569;
+  font-size: 1.0625rem;
+  line-height: 1.7;
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.toggle {
+  display: inline-flex;
+  gap: 0.5rem;
+  border-radius: 9999px;
+  background: rgba(99, 102, 241, 0.08);
+  padding: 0.25rem;
+  align-self: center;
+  margin-top: 1rem;
+}
+
+.toggleButton {
+  border: none;
+  background: transparent;
+  padding: 0.55rem 1.5rem;
+  border-radius: 9999px;
+  font-weight: 600;
+  color: #4338ca;
+  cursor: pointer;
+  transition: background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.toggleButtonActive {
+  background: #4f46e5;
+  color: #ffffff;
+  box-shadow: 0 10px 25px rgba(79, 70, 229, 0.25);
+}
+
+.plans {
+  padding: 0 1.5rem;
+}
+
+.plansInner {
+  margin: 0 auto;
+  max-width: 1100px;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.cardsGrid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.planCard {
+  position: relative;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(248, 250, 252, 0.9));
+  border-radius: 1.5rem;
+  padding: 2rem 1.75rem;
+  box-shadow: 0 25px 45px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  border: 1px solid rgba(99, 102, 241, 0.08);
+}
+
+.planRibbon {
+  position: absolute;
+  top: 1.25rem;
+  right: 1.25rem;
+  background: #f97316;
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  text-transform: uppercase;
+}
+
+.planName {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.planHeadline {
+  color: #22c55e;
+  font-weight: 600;
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+}
+
+.planPrice {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.35rem;
+}
+
+.planPriceValue {
+  font-size: 2.25rem;
+  font-weight: 700;
+  color: #1e1b4b;
+}
+
+.planPricePeriod {
+  color: #475569;
+  font-size: 0.95rem;
+}
+
+.planFeatures {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  color: #334155;
+}
+
+.planFeatures li::before {
+  content: "";
+  display: inline-block;
+  width: 0.65rem;
+  height: 0.65rem;
+  margin-right: 0.5rem;
+  border-radius: 9999px;
+  background: linear-gradient(135deg, #22c55e, #16a34a);
+  flex-shrink: 0;
+}
+
+.planFeatures li {
+  display: flex;
+  align-items: center;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.planCta {
+  margin-top: auto;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 9999px;
+  background: #4f46e5;
+  color: #fff;
+  font-weight: 600;
+  padding: 0.85rem 1.5rem;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.planCta:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 25px rgba(79, 70, 229, 0.25);
+}
+
+.footer {
+  border-top: 1px solid rgba(148, 163, 184, 0.35);
+  padding-top: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: center;
+  text-align: center;
+}
+
+.paymentNote {
+  color: #475569;
+  font-size: 0.95rem;
+}
+
+.paymentMethods {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
+.paymentChip {
+  border-radius: 9999px;
+  background: rgba(148, 163, 184, 0.2);
+  color: #0f172a;
+  font-weight: 600;
+  padding: 0.4rem 1rem;
+  font-size: 0.85rem;
+}
+
+@media (max-width: 768px) {
+  .hero {
+    padding-top: 4rem;
+  }
+
+  .page {
+    gap: 3rem;
+  }
+
+  .planCard {
+    border-radius: 1.25rem;
+    padding: 1.75rem 1.5rem;
+  }
+}

--- a/components/PricingTemplate.tsx
+++ b/components/PricingTemplate.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import type { PricingCategory, PricingPageData } from "../lib/pricing";
+import styles from "./PricingTemplate.module.css";
+
+type PricingTemplateProps = {
+  data: PricingPageData;
+};
+
+function resolveInitialCategory(categories: PricingCategory[]): string {
+  return categories[0]?.id ?? "";
+}
+
+export default function PricingTemplate({ data }: PricingTemplateProps) {
+  const [activeCategoryId, setActiveCategoryId] = useState<string>(() => resolveInitialCategory(data.categories));
+
+  const activeCategory = data.categories.find(category => category.id === activeCategoryId) ?? data.categories[0];
+
+  return (
+    <main className={styles.page}>
+      <section className={styles.hero}>
+        <div className={styles.heroInner}>
+          <p className={styles.heroHighlight}>{data.highlight}</p>
+          <h1 className={styles.heroTitle}>{data.title}</h1>
+          <p className={styles.heroSubtitle}>{data.subtitle}</p>
+
+          {data.categories.length > 1 && (
+            <div className={styles.toggle} role="tablist" aria-label="Pricing options">
+              {data.categories.map(category => {
+                const isActive = category.id === activeCategory?.id;
+                return (
+                  <button
+                    key={category.id}
+                    type="button"
+                    role="tab"
+                    aria-selected={isActive}
+                    className={`${styles.toggleButton} ${isActive ? styles.toggleButtonActive : ""}`}
+                    onClick={() => setActiveCategoryId(category.id)}
+                  >
+                    {category.label}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </section>
+
+      <section className={styles.plans}>
+        <div className={styles.plansInner}>
+          <div className={styles.cardsGrid}>
+            {activeCategory?.tiers.map(tier => (
+              <article key={tier.id} className={styles.planCard}>
+                {tier.ribbon && <span className={styles.planRibbon}>{tier.ribbon}</span>}
+                <h2 className={styles.planName}>{tier.name}</h2>
+                {tier.headline && <p className={styles.planHeadline}>{tier.headline}</p>}
+                <p className={styles.planPrice}>
+                  <span className={styles.planPriceValue}>{tier.price}</span>
+                  <span className={styles.planPricePeriod}>{tier.period}</span>
+                </p>
+                <ul className={styles.planFeatures}>
+                  {tier.features.map(feature => (
+                    <li key={feature}>{feature}</li>
+                  ))}
+                </ul>
+                <Link href={tier.ctaHref} className={styles.planCta} target="_blank" rel="noopener">
+                  {tier.ctaLabel ?? "Buy Now"}
+                </Link>
+              </article>
+            ))}
+          </div>
+
+          <footer className={styles.footer}>
+            <p className={styles.paymentNote}>{data.paymentNote}</p>
+            <div className={styles.paymentMethods} aria-label="Supported payment methods">
+              {data.paymentMethods.map(method => (
+                <span key={method} className={styles.paymentChip}>
+                  {method}
+                </span>
+              ))}
+            </div>
+          </footer>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/components/TopProductsTabs.module.css
+++ b/components/TopProductsTabs.module.css
@@ -1,0 +1,165 @@
+.section {
+  margin-top: clamp(0rem, 2vw, 1rem);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.97) 0%, #f2f6ff 100%);
+  padding: clamp(3rem, 7vw, 5.5rem) 0;
+}
+
+.sectionInner {
+  width: min(100%, 1120px);
+  margin: 0 auto;
+  padding: 0 clamp(1.5rem, 6vw, 5.5rem);
+  display: grid;
+  gap: clamp(1.75rem, 3vw, 2.5rem);
+  box-sizing: border-box;
+}
+
+.header {
+  display: grid;
+  gap: 0.6rem;
+  max-width: 40rem;
+}
+
+.title {
+  margin: 0;
+  font-size: clamp(1.75rem, 4vw, 2.5rem);
+  font-weight: 700;
+  color: #111827;
+}
+
+.subtitle {
+  margin: 0;
+  color: #475569;
+  line-height: 1.6;
+}
+
+.tablistWrapper {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+}
+
+.tabButton {
+  appearance: none;
+  border: none;
+  border-radius: 999px;
+  padding: 0.65rem 1.3rem;
+  font-weight: 600;
+  background: rgba(15, 23, 42, 0.08);
+  color: #0f172a;
+  cursor: pointer;
+  transition: background 150ms ease, transform 150ms ease, color 150ms ease;
+}
+
+.tabButton:hover {
+  transform: translateY(-1px);
+}
+
+.tabButton:focus-visible {
+  outline: 3px solid rgba(56, 189, 248, 0.65);
+  outline-offset: 3px;
+}
+
+.tabButtonActive {
+  background: #111b2e;
+  color: #f8fafc;
+}
+
+.panel {
+  background: rgba(255, 255, 255, 0.82);
+  border-radius: clamp(1.5rem, 3vw, 2.5rem);
+  padding: clamp(1.4rem, 3vw, 2.25rem);
+  display: grid;
+  gap: clamp(1.4rem, 2.5vw, 2rem);
+  box-shadow: 0 28px 64px -48px rgba(15, 23, 42, 0.55);
+}
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: clamp(1.1rem, 2.5vw, 1.75rem);
+}
+
+.card {
+  background: rgba(246, 249, 255, 0.7);
+  border-radius: 1.4rem;
+  padding: clamp(1.1rem, 2.5vw, 1.6rem);
+  display: grid;
+  gap: 0.8rem;
+  min-height: 100%;
+}
+
+.cardHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.cardTitle {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #111827;
+}
+
+.cardPrice {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #2563eb;
+}
+
+.featureList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.35rem;
+  color: #4b5563;
+  font-size: 0.95rem;
+}
+
+.featureItem {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.featureDot {
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 999px;
+  background: #38bdf8;
+}
+
+.cardMeta {
+  margin: 0;
+  color: #1f2937;
+  font-weight: 500;
+}
+
+.note {
+  margin: 0;
+  color: #475569;
+  line-height: 1.6;
+}
+
+@media (max-width: 600px) {
+  .cards {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  }
+}
+
+@media (max-width: 480px) {
+  .section {
+    padding: 2.75rem 0;
+  }
+
+  .sectionInner {
+    padding: 0 1.25rem;
+  }
+
+  .tabButton {
+    flex: 1 1 100%;
+    justify-content: center;
+  }
+}

--- a/components/TopProductsTabs.tsx
+++ b/components/TopProductsTabs.tsx
@@ -1,23 +1,26 @@
-﻿"use client";
-import { useState } from "react";
-import { CATEGORIES, Category } from "../lib/products";
+"use client";
 
-function TabButton({
-  active, onClick, label
-}: { active: boolean; onClick: () => void; label: string }) {
+import React, { useState } from "react";
+import { CATEGORIES, CategoryId } from "../lib/products";
+import styles from "./TopProductsTabs.module.css";
+
+type TabButtonProps = {
+  categoryId: CategoryId;
+  label: string;
+  isActive: boolean;
+  onSelect: (id: CategoryId) => void;
+};
+
+function TabButton({ categoryId, label, isActive, onSelect }: TabButtonProps) {
   return (
     <button
+      type="button"
+      id={`${categoryId}-tab`}
+      className={`${styles.tabButton} ${isActive ? styles.tabButtonActive : ""}`}
       role="tab"
-      aria-selected={active ? "true" : "false"}
-      onClick={onClick}
-      style={{
-        padding: "10px 16px",
-        borderRadius: 10,
-        border: "1px solid rgba(0,0,0,0.08)",
-        background: active ? "#111" : "#fff",
-        color: active ? "#fff" : "#111",
-        cursor: "pointer"
-      }}
+      aria-selected={isActive}
+      aria-controls={`${categoryId}-panel`}
+      onClick={() => onSelect(categoryId)}
     >
       {label}
     </button>
@@ -25,41 +28,57 @@ function TabButton({
 }
 
 export default function TopProductsTabs() {
-  const [active, setActive] = useState<Category["id"]>("isp");
-  const current = CATEGORIES.find(c => c.id === active)!;
+  const [activeCategory, setActiveCategory] = useState<CategoryId>(CATEGORIES[0].id);
+  const current = CATEGORIES.find(category => category.id === activeCategory)!;
 
   return (
-    <section style={{ marginTop: 48 }}>
-      <h2 style={{ fontSize: 28, marginBottom: 12 }}>Top Products by SoksLine</h2>
+    <section className={styles.section} id="top-products">
+      <div className={styles.sectionInner}>
+        <div className={styles.header}>
+          <h2 className={styles.title}>Top Products by SoksLine</h2>
+          <p className={styles.subtitle}>{current.tagline}</p>
+        </div>
 
-      <div role="tablist" aria-label="Product categories" style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
-        <TabButton active={active === "isp"} onClick={() => setActive("isp")} label="Static Residential (ISP)" />
-        <TabButton active={active === "ipv6"} onClick={() => setActive("ipv6")} label="Static Residential (ISP) IPv6" />
-        <TabButton active={active === "rotating"} onClick={() => setActive("rotating")} label="Rotating Residential" />
-      </div>
+        <div role="tablist" aria-label="Категории продуктов" className={styles.tablistWrapper}>
+          {CATEGORIES.map(category => (
+            <TabButton
+              key={category.id}
+              categoryId={category.id}
+              label={category.title}
+              isActive={category.id === activeCategory}
+              onSelect={setActiveCategory}
+            />
+          ))}
+        </div>
 
-      <div role="tabpanel" aria-live="polite" style={{ marginTop: 20, background: "#fafafa", borderRadius: 14, padding: 16, border: "1px solid rgba(0,0,0,0.06)" }}>
-        <table style={{ width: "100%", borderCollapse: "collapse" }}>
-          <thead>
-            <tr style={{ textAlign: "left" }}>
-              <th style={{ padding: "10px 8px" }}>Название</th>
-              <th style={{ padding: "10px 8px" }}>Цена</th>
-              <th style={{ padding: "10px 8px" }}>Особенности</th>
-            </tr>
-          </thead>
-          <tbody>
-            {current.items.map((p, idx) => (
-              <tr key={idx} style={{ borderTop: "1px solid rgba(0,0,0,0.06)" }}>
-                <td style={{ padding: "10px 8px" }}>{p.name}</td>
-                <td style={{ padding: "10px 8px", whiteSpace: "nowrap" }}>{p.price ?? "—"}</td>
-                <td style={{ padding: "10px 8px" }}>
-                  {p.features?.join(" · ") ?? "—"}
-                </td>
-              </tr>
+        <div
+          id={`${current.id}-panel`}
+          role="tabpanel"
+          tabIndex={0}
+          aria-labelledby={`${current.id}-tab`}
+          className={styles.panel}
+        >
+          <div className={styles.cards}>
+            {current.items.map(item => (
+              <article key={item.name} className={styles.card}>
+                <div className={styles.cardHeader}>
+                  <h3 className={styles.cardTitle}>{item.name}</h3>
+                  <p className={styles.cardPrice}>{item.price}</p>
+                </div>
+                <ul className={styles.featureList}>
+                  {item.features.map(feature => (
+                    <li key={feature} className={styles.featureItem}>
+                      <span className={styles.featureDot} aria-hidden="true" />
+                      <span>{feature}</span>
+                    </li>
+                  ))}
+                </ul>
+                {item.bestFor && <p className={styles.cardMeta}>{item.bestFor}</p>}
+              </article>
             ))}
-          </tbody>
-        </table>
-        {current.note && <p style={{ marginTop: 12, color: "#555" }}>{current.note}</p>}
+          </div>
+          {current.note && <p className={styles.note}>{current.note}</p>}
+        </div>
       </div>
     </section>
   );

--- a/lib/pricing.ts
+++ b/lib/pricing.ts
@@ -1,0 +1,361 @@
+export type PricingTier = {
+  id: string;
+  name: string;
+  headline?: string;
+  price: string;
+  period: string;
+  description?: string;
+  features: string[];
+  ctaLabel?: string;
+  ctaHref: string;
+  ribbon?: string;
+};
+
+export type PricingCategory = {
+  id: string;
+  label: string;
+  tiers: PricingTier[];
+};
+
+export type PricingPageData = {
+  slug: string;
+  title: string;
+  subtitle: string;
+  highlight: string;
+  categories: PricingCategory[];
+  paymentNote: string;
+  paymentMethods: string[];
+};
+
+const ORDER_LINK = "https://soksline.com/order";
+
+export const STATIC_RESIDENTIAL_PRICING: PricingPageData = {
+  slug: "static-residential",
+  title: "Static Residential Proxy Plans – Speeds Up To 1Gbps",
+  subtitle:
+    "Static residential proxies to guarantee consistent access for as long as you need.",
+  highlight: "Reliable residential IPs • High-performance routing • Sticky sessions",
+  paymentNote: "SSL Secure Payment. Your information is protected by 256-bit SSL.",
+  paymentMethods: ["Visa", "Mastercard", "AMEX", "PayPal", "BTC", "USDT"],
+  categories: [
+    {
+      id: "basic",
+      label: "Basic",
+      tiers: [
+        {
+          id: "trial",
+          name: "7 Day Trial",
+          price: "$1.99",
+          period: "per proxy",
+          features: [
+            "Unlimited Bandwidth",
+            "Unlimited Threads",
+            "Sticky Sessions",
+            "SOCKS5 and HTTP/S",
+            "Country & ISP-level targeting"
+          ],
+          ctaHref: ORDER_LINK
+        },
+        {
+          id: "month",
+          name: "1 Month",
+          headline: "Most Popular",
+          price: "$1.49",
+          period: "per proxy",
+          ribbon: "BEST FORMULA",
+          features: [
+            "Unlimited Bandwidth",
+            "Unlimited Threads",
+            "Sticky Sessions",
+            "SOCKS5 and HTTP/S",
+            "Country & ISP-level targeting"
+          ],
+          ctaHref: ORDER_LINK
+        },
+        {
+          id: "year",
+          name: "12 Months",
+          headline: "Save 15%",
+          price: "$1.27",
+          period: "per proxy",
+          features: [
+            "Unlimited Bandwidth",
+            "Unlimited Threads",
+            "Sticky Sessions",
+            "SOCKS5 and HTTP/S",
+            "Country & ISP-level targeting"
+          ],
+          ctaHref: ORDER_LINK
+        }
+      ]
+    },
+    {
+      id: "premium",
+      label: "Premium",
+      tiers: [
+        {
+          id: "premium-25",
+          name: "25 Proxies",
+          price: "$2.39",
+          period: "per proxy / month",
+          features: [
+            "Unlimited Bandwidth",
+            "Dedicated Subnets",
+            "Sticky Sessions",
+            "Dual Authentication",
+            "Priority Support"
+          ],
+          ctaHref: ORDER_LINK
+        },
+        {
+          id: "premium-100",
+          name: "100 Proxies",
+          ribbon: "SAVE 10%",
+          price: "$2.19",
+          period: "per proxy / month",
+          features: [
+            "Unlimited Bandwidth",
+            "Dedicated Subnets",
+            "Sticky Sessions",
+            "Dual Authentication",
+            "Priority Support"
+          ],
+          ctaHref: ORDER_LINK
+        },
+        {
+          id: "premium-250",
+          name: "250 Proxies",
+          price: "$1.99",
+          period: "per proxy / month",
+          features: [
+            "Unlimited Bandwidth",
+            "Dedicated Subnets",
+            "Sticky Sessions",
+            "Dual Authentication",
+            "Priority Support"
+          ],
+          ctaHref: ORDER_LINK
+        }
+      ]
+    }
+  ]
+};
+
+export const STATIC_IPV6_PRICING: PricingPageData = {
+  slug: "static-residential-ipv6",
+  title: "Affordable IPv6 Static Residential Proxy Pricing & Plans",
+  subtitle:
+    "Access the web safely and without any restrictions with Static Residential Proxies IPv6 for all your needs.",
+  highlight: "Flexible pricing • SOCKS5 and HTTP support • Rotating subnets",
+  paymentNote: "SSL Secure Payment. Your information is protected by 256-bit SSL.",
+  paymentMethods: ["Visa", "Mastercard", "AMEX", "PayPal", "BTC", "USDT"],
+  categories: [
+    {
+      id: "monthly",
+      label: "Monthly",
+      tiers: [
+        {
+          id: "ipv6-10",
+          name: "10 Proxies",
+          price: "$0.63",
+          period: "per proxy per month",
+          features: [
+            "Unlimited Bandwidth",
+            "100 Threads",
+            "Sticky Sessions",
+            "SOCKS5 & HTTP/S",
+            "Geo Targeting"
+          ],
+          ctaHref: ORDER_LINK
+        },
+        {
+          id: "ipv6-100",
+          name: "100 Proxies",
+          ribbon: "SAVE 5%",
+          price: "$0.59",
+          period: "per proxy per month",
+          features: [
+            "Unlimited Bandwidth",
+            "100 Threads",
+            "Sticky Sessions",
+            "SOCKS5 & HTTP/S",
+            "Geo Targeting"
+          ],
+          ctaHref: ORDER_LINK
+        },
+        {
+          id: "ipv6-500",
+          name: "500 Proxies",
+          price: "$0.57",
+          period: "per proxy per month",
+          features: [
+            "Unlimited Bandwidth",
+            "100 Threads",
+            "Sticky Sessions",
+            "SOCKS5 & HTTP/S",
+            "Geo Targeting"
+          ],
+          ctaHref: ORDER_LINK
+        }
+      ]
+    },
+    {
+      id: "yearly",
+      label: "Yearly",
+      tiers: [
+        {
+          id: "ipv6-year-10",
+          name: "10 Proxies",
+          price: "$0.52",
+          period: "per proxy per month",
+          features: [
+            "Unlimited Bandwidth",
+            "100 Threads",
+            "Sticky Sessions",
+            "SOCKS5 & HTTP/S",
+            "Geo Targeting"
+          ],
+          ctaHref: ORDER_LINK
+        },
+        {
+          id: "ipv6-year-100",
+          name: "100 Proxies",
+          ribbon: "SAVE 10%",
+          price: "$0.49",
+          period: "per proxy per month",
+          features: [
+            "Unlimited Bandwidth",
+            "100 Threads",
+            "Sticky Sessions",
+            "SOCKS5 & HTTP/S",
+            "Geo Targeting"
+          ],
+          ctaHref: ORDER_LINK
+        },
+        {
+          id: "ipv6-year-500",
+          name: "500 Proxies",
+          price: "$0.45",
+          period: "per proxy per month",
+          features: [
+            "Unlimited Bandwidth",
+            "100 Threads",
+            "Sticky Sessions",
+            "SOCKS5 & HTTP/S",
+            "Geo Targeting"
+          ],
+          ctaHref: ORDER_LINK
+        }
+      ]
+    }
+  ]
+};
+
+export const ROTATING_RESIDENTIAL_PRICING: PricingPageData = {
+  slug: "rotating-residential",
+  title: "Rotating Residential Proxy Plans – Access 6M+ Global IPs",
+  subtitle:
+    "Get Residential Proxies with 6 million+ residential IP addresses. Access to 100+ countries.",
+  highlight: "Affordable pricing • Unlimited threads • Sticky/rotating sessions",
+  paymentNote: "SSL Secure Payment. Your information is protected by 256-bit SSL.",
+  paymentMethods: ["Visa", "Mastercard", "AMEX", "PayPal", "BTC", "USDT"],
+  categories: [
+    {
+      id: "payg",
+      label: "Pay-as-you-go",
+      tiers: [
+        {
+          id: "payg-1",
+          name: "1 GB",
+          price: "$4.99",
+          period: "per GB",
+          features: [
+            "User/Password",
+            "Unlimited Threads",
+            "Sticky/Rotating Sessions",
+            "SOCKS5 and HTTP/S",
+            "< 100 Mbps"
+          ],
+          ctaHref: ORDER_LINK
+        },
+        {
+          id: "payg-50",
+          name: "50 GB",
+          price: "$4.99",
+          period: "per GB",
+          features: [
+            "User/Password",
+            "Unlimited Threads",
+            "Sticky/Rotating Sessions",
+            "SOCKS5 and HTTP/S",
+            "< 100 Mbps"
+          ],
+          ctaHref: ORDER_LINK
+        },
+        {
+          id: "payg-100",
+          name: "100 GB",
+          price: "$4.99",
+          period: "per GB",
+          features: [
+            "User/Password",
+            "Unlimited Threads",
+            "Sticky/Rotating Sessions",
+            "SOCKS5 and HTTP/S",
+            "< 100 Mbps"
+          ],
+          ctaHref: ORDER_LINK
+        }
+      ]
+    },
+    {
+      id: "large",
+      label: "Large Package",
+      tiers: [
+        {
+          id: "large-100",
+          name: "100 GB",
+          price: "$4.49",
+          period: "per GB",
+          ribbon: "SAVE 5%",
+          features: [
+            "User/Password",
+            "Unlimited Threads",
+            "Sticky/Rotating Sessions",
+            "SOCKS5 and HTTP/S",
+            "< 100 Mbps"
+          ],
+          ctaHref: ORDER_LINK
+        },
+        {
+          id: "large-250",
+          name: "250 GB",
+          price: "$4.29",
+          period: "per GB",
+          features: [
+            "User/Password",
+            "Unlimited Threads",
+            "Sticky/Rotating Sessions",
+            "SOCKS5 and HTTP/S",
+            "< 100 Mbps"
+          ],
+          ctaHref: ORDER_LINK
+        },
+        {
+          id: "large-500",
+          name: "500 GB",
+          price: "$3.99",
+          period: "per GB",
+          features: [
+            "User/Password",
+            "Unlimited Threads",
+            "Sticky/Rotating Sessions",
+            "SOCKS5 and HTTP/S",
+            "< 100 Mbps"
+          ],
+          ctaHref: ORDER_LINK
+        }
+      ]
+    }
+  ]
+};

--- a/lib/products.ts
+++ b/lib/products.ts
@@ -1,13 +1,17 @@
-﻿export type Product = {
+export type CategoryId = "isp" | "ipv6" | "rotating";
+
+export type ProductOffering = {
   name: string;
-  price?: string;         // строкой, чтобы легко писать "from $X"
-  features?: string[];
+  price: string;
+  features: string[];
+  bestFor?: string;
 };
 
 export type Category = {
-  id: "isp" | "ipv6" | "rotating";
+  id: CategoryId;
   title: string;
-  items: Product[];
+  tagline: string;
+  items: ProductOffering[];
   note?: string;
 };
 
@@ -15,28 +19,61 @@ export const CATEGORIES: Category[] = [
   {
     id: "isp",
     title: "Static Residential (ISP)",
+    tagline: "Статичные резидентские прокси для стабильной работы и кабинетных задач.",
     items: [
-      { name: "US / EU (shared pool)", price: "from $2.50/IP", features: ["Sticky", "HTTP/SOCKS", "KYC free"] },
-      { name: "Dedicated country",      price: "from $3.50/IP", features: ["Geo-targeting", "Replace 1x/mo"] }
+      {
+        name: "US / EU (shared pool)",
+        price: "от $2.50 / IP",
+        features: ["Sticky до 24 ч", "HTTP / SOCKS5", "Без KYC"],
+        bestFor: "Управление рекламой и аккаунтами."
+      },
+      {
+        name: "Dedicated country",
+        price: "от $3.50 / IP",
+        features: ["Точный геотаргетинг", "Замена 1 раз/мес", "Поддержка API"],
+        bestFor: "Создание фермы под конкретный регион."
+      }
     ],
-    note: "Оптимально для стабильных задач: антидетект, кабинеты, маркетплейсы."
+    note: "Оптимально для стабильных задач: антидетект, кабинеты и маркетплейсы."
   },
   {
     id: "ipv6",
     title: "Static Residential (ISP) IPv6",
+    tagline: "Доступные IPv6-пулы с высокой пропускной способностью и нативным резолвингом.",
     items: [
-      { name: "Global IPv6 pool", price: "from $1.20/IP", features: ["IPv6 only", "High throughput"] },
-      { name: "Country IPv6",     price: "from $1.60/IP", features: ["Geo-targeting", "Low price per IP"] }
+      {
+        name: "Global IPv6 pool",
+        price: "от $1.20 / IP",
+        features: ["IPv6 only", "Высокая скорость", "HTTP / SOCKS5"],
+        bestFor: "Парсинг и регистрация с минимальной себестоимостью."
+      },
+      {
+        name: "Country IPv6",
+        price: "от $1.60 / IP",
+        features: ["Гео по требованию", "Автоматическая выдача", "Готово к масштабированию"],
+        bestFor: "Проекты с геопривязкой и массовыми потоками."
+      }
     ],
-    note: "IPv6 — дешево и быстро; убедись, что целевые сайты поддерживают IPv6."
+    note: "IPv6 — дешево и быстро; убедитесь, что целевые сайты поддерживают IPv6."
   },
   {
     id: "rotating",
     title: "Rotating Residential",
+    tagline: "Ротация IP по запросу с балансом между скоростью и анонимностью.",
     items: [
-      { name: "Standard rotation", price: "from $10/GB", features: ["Residential pool", "Sticky up to 30 min"] },
-      { name: "Premium rotation",  price: "from $15/GB", features: ["Low spam", "Top ISPs"] }
+      {
+        name: "Standard rotation",
+        price: "от $10 / GB",
+        features: ["Резидентский пул", "Sticky до 30 мин", "HTTP / SOCKS5"],
+        bestFor: "Сбор данных и массовые проверки."
+      },
+      {
+        name: "Premium rotation",
+        price: "от $15 / GB",
+        features: ["Минимум спама", "Топовые ASN", "Выделенные сессии"],
+        bestFor: "Чувствительные сценарии с повышенным контролем качества."
+      }
     ],
-    note: "Ротация для парсинга/скрейпа и высоких объёмов."
+    note: "Ротация для парсинга, скрейпа и высоких объёмов."
   }
 ];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "compilerOptions": {
     "target": "ES2020",
     "lib": [
@@ -15,7 +15,7 @@
     "moduleResolution": "Bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "incremental": true,
     "types": [
       "vitest/globals",


### PR DESCRIPTION
## Summary
- add reusable pricing template and plan datasets for residential offerings
- create static residential, IPv6, and rotating residential pricing routes and wire them into the pricing dropdown
- style the new pricing layouts with full-width hero, plan cards, and payment note

## Testing
- npm run lint
- CI=1 npm run build
- npm test

## Screenshots
![Static residential pricing](browser:/invocations/tgnlqzdu/artifacts/artifacts/static-residential.png)


------
https://chatgpt.com/codex/tasks/task_e_68d90a10ef40832a97e73dc7ed165d53