### PR TITLE
Reorder resources FAQ sequence

### DIFF
--- a/components/HeaderNav.module.css
+++ b/components/HeaderNav.module.css
@@ -107,7 +107,7 @@
   border-radius: 1.2rem;
   box-shadow: 0 28px 60px -40px rgba(2, 6, 23, 0.6);
   display: none;
-  min-width: 19.2rem;
+  min-width: 23rem;
   gap: 1.5rem;
 }
 
@@ -139,7 +139,7 @@
 
 .dropdownLink {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 1rem;
   text-decoration: none;

--- a/components/HeaderNav.tsx
+++ b/components/HeaderNav.tsx
@@ -98,14 +98,42 @@ const NAV_CONTENT: Record<Locale, NavigationCopy> = {
           {
             heading: "Материалы",
             items: [
-              { label: "С чего начать", href: "https://soksline.com/getting-started" },
-              { label: "Блог", href: "https://soksline.com/blog" },
-              { label: "Политика AML", href: "https://soksline.com/aml-policy" },
+              {
+                label: "Can I select a proxy location?",
+                href: "https://soksline.com/blog/can-i-select-a-proxy-location",
+              },
+              {
+                label: "What are the targeting options for our proxies?",
+                href: "https://soksline.com/blog/what-are-the-targeting-options-for-our-proxies",
+              },
+              {
+                label: "What solutions do you offer?",
+                href: "https://soksline.com/blog/what-solutions-do-you-offer",
+              },
+            ],
+          },
+          {
+            items: [
+              {
+                label: "How long does it take to receive my ordered proxies?",
+                href: "https://soksline.com/blog/how-long-does-it-take-to-receive-my-ordered-proxies",
+              },
+              {
+                label: "Why Residential Proxies?",
+                href: "https://soksline.com/blog/why-residential-proxies",
+              },
+              {
+                label: "What is a rotating proxy?",
+                href: "https://soksline.com/blog/what-is-a-rotating-proxy",
+              },
             ],
           },
           {
             heading: "Компания",
-            items: [{ label: "Связаться", href: "https://soksline.com/contact" }],
+            items: [
+              { label: "AMP Policy", href: "https://soksline.com/aml-policy" },
+              { label: "Contacts", href: "https://soksline.com/contact" },
+            ],
           },
         ],
       },
@@ -178,14 +206,42 @@ const NAV_CONTENT: Record<Locale, NavigationCopy> = {
           {
             heading: "Resources",
             items: [
-              { label: "Getting Started", href: "https://soksline.com/getting-started" },
-              { label: "Blog", href: "https://soksline.com/blog" },
-              { label: "AML Policy", href: "https://soksline.com/aml-policy" },
+              {
+                label: "Can I select a proxy location?",
+                href: "https://soksline.com/blog/can-i-select-a-proxy-location",
+              },
+              {
+                label: "What are the targeting options for our proxies?",
+                href: "https://soksline.com/blog/what-are-the-targeting-options-for-our-proxies",
+              },
+              {
+                label: "What solutions do you offer?",
+                href: "https://soksline.com/blog/what-solutions-do-you-offer",
+              },
+            ],
+          },
+          {
+            items: [
+              {
+                label: "How long does it take to receive my ordered proxies?",
+                href: "https://soksline.com/blog/how-long-does-it-take-to-receive-my-ordered-proxies",
+              },
+              {
+                label: "Why Residential Proxies?",
+                href: "https://soksline.com/blog/why-residential-proxies",
+              },
+              {
+                label: "What is a rotating proxy?",
+                href: "https://soksline.com/blog/what-is-a-rotating-proxy",
+              },
             ],
           },
           {
             heading: "Company",
-            items: [{ label: "Contact Us", href: "https://soksline.com/contact" }],
+            items: [
+              { label: "AMP Policy", href: "https://soksline.com/aml-policy" },
+              { label: "Contacts", href: "https://soksline.com/contact" },
+            ],
           },
         ],
       },


### PR DESCRIPTION
## Summary
- reorder the resource dropdown FAQs in both locales to match the requested sequence while keeping the two-column layout intact

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68daccfd1248832a8703d56a44280b75