### PR TITLE
Reorganize resources dropdown into two columns

### DIFF
--- a/components/HeaderNav.tsx
+++ b/components/HeaderNav.tsx
@@ -96,31 +96,35 @@ const NAV_CONTENT: Record<Locale, NavigationCopy> = {
         label: "Ресурсы",
         sections: [
           {
-            heading: "Материалы",
+            heading: "Ресурсы",
             items: [
-              {
-                label: "What is a rotating proxy?",
-                href: "https://soksline.com/blog/what-is-a-rotating-proxy",
-              },
               {
                 label: "Can I select a proxy location?",
                 href: "https://soksline.com/blog/can-i-select-a-proxy-location",
               },
               {
-                label: "How long does it take to receive my ordered proxies?",
-                href: "https://soksline.com/blog/how-long-does-it-take-to-receive-my-ordered-proxies",
+                label: "What are the targeting options for our proxies?",
+                href: "https://soksline.com/blog/what-are-the-targeting-options-for-our-proxies",
               },
               {
                 label: "What solutions do you offer?",
                 href: "https://soksline.com/blog/what-solutions-do-you-offer",
+              },
+            ],
+          },
+          {
+            items: [
+              {
+                label: "How long does it take to receive my ordered proxies?",
+                href: "https://soksline.com/blog/how-long-does-it-take-to-receive-my-ordered-proxies",
               },
               {
                 label: "Why Residential Proxies?",
                 href: "https://soksline.com/blog/why-residential-proxies",
               },
               {
-                label: "What are the targeting options for our proxies?",
-                href: "https://soksline.com/blog/what-are-the-targeting-options-for-our-proxies",
+                label: "What is a rotating proxy?",
+                href: "https://soksline.com/blog/what-is-a-rotating-proxy",
               },
             ],
           },
@@ -203,28 +207,32 @@ const NAV_CONTENT: Record<Locale, NavigationCopy> = {
             heading: "Resources",
             items: [
               {
-                label: "What is a rotating proxy?",
-                href: "https://soksline.com/blog/what-is-a-rotating-proxy",
-              },
-              {
                 label: "Can I select a proxy location?",
                 href: "https://soksline.com/blog/can-i-select-a-proxy-location",
               },
               {
-                label: "How long does it take to receive my ordered proxies?",
-                href: "https://soksline.com/blog/how-long-does-it-take-to-receive-my-ordered-proxies",
+                label: "What are the targeting options for our proxies?",
+                href: "https://soksline.com/blog/what-are-the-targeting-options-for-our-proxies",
               },
               {
                 label: "What solutions do you offer?",
                 href: "https://soksline.com/blog/what-solutions-do-you-offer",
+              },
+            ],
+          },
+          {
+            items: [
+              {
+                label: "How long does it take to receive my ordered proxies?",
+                href: "https://soksline.com/blog/how-long-does-it-take-to-receive-my-ordered-proxies",
               },
               {
                 label: "Why Residential Proxies?",
                 href: "https://soksline.com/blog/why-residential-proxies",
               },
               {
-                label: "What are the targeting options for our proxies?",
-                href: "https://soksline.com/blog/what-are-the-targeting-options-for-our-proxies",
+                label: "What is a rotating proxy?",
+                href: "https://soksline.com/blog/what-is-a-rotating-proxy",
               },
             ],
           },


### PR DESCRIPTION
## Summary
- split the Resources dropdown links into two balanced columns for both locales to match the new layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dae757e11c832a9f01daa262211df0