### PR TITLE
Add Why Residential Proxies resource page

### DIFF
--- a/app/resources/what-is-a-rotating-proxy/page.module.css
+++ b/app/resources/what-is-a-rotating-proxy/page.module.css
@@ -1,0 +1,90 @@
+.page {
+  min-height: calc(100vh - 80px);
+  display: flex;
+  justify-content: center;
+  padding: 6rem 1.5rem 4rem;
+  box-sizing: border-box;
+}
+
+.article {
+  width: min(720px, 100%);
+  background: linear-gradient(160deg, rgba(34, 49, 96, 0.7), rgba(16, 24, 44, 0.85));
+  border: 1px solid rgba(124, 144, 212, 0.25);
+  border-radius: 24px;
+  padding: 3.5rem clamp(1.5rem, 4vw, 3rem);
+  color: #f4f6ff;
+  box-shadow: 0 24px 40px rgba(9, 14, 30, 0.6);
+  backdrop-filter: blur(12px);
+}
+
+.header {
+  display: grid;
+  gap: 1rem;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.3em;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: rgba(172, 192, 255, 0.85);
+}
+
+.title {
+  margin: 0;
+  font-size: clamp(2.25rem, 4vw, 3rem);
+  line-height: 1.1;
+}
+
+.lead {
+  margin: 0;
+  font-size: 1.125rem;
+  line-height: 1.7;
+  color: rgba(230, 234, 255, 0.88);
+}
+
+.section {
+  margin-top: 2.5rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.sectionTitle {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #9fb6ff;
+}
+
+.section p {
+  margin: 0;
+  line-height: 1.7;
+  color: rgba(230, 234, 255, 0.9);
+}
+
+.list {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 0.85rem;
+  line-height: 1.6;
+  color: rgba(230, 234, 255, 0.9);
+}
+
+.list strong {
+  color: #f4f6ff;
+}
+
+.footer {
+  margin-top: 3rem;
+  padding-top: 2rem;
+  border-top: 1px solid rgba(124, 144, 212, 0.25);
+  color: rgba(230, 234, 255, 0.85);
+  line-height: 1.7;
+}
+
+@media (max-width: 640px) {
+  .article {
+    padding: 2.5rem 1.5rem;
+  }
+}

--- a/app/resources/what-is-a-rotating-proxy/page.tsx
+++ b/app/resources/what-is-a-rotating-proxy/page.tsx
@@ -1,0 +1,58 @@
+import styles from "./page.module.css";
+
+export const metadata = {
+  title: "What is a Rotating Proxy? | SoksLine",
+  description:
+    "Learn what rotating residential proxies are, how sessions work, and what to expect from expiration and renewals at SoksLine.",
+};
+
+export default function Page() {
+  return (
+    <main className={styles.page}>
+      <article className={styles.article}>
+        <header className={styles.header}>
+          <span className={styles.eyebrow}>Guide</span>
+          <h1 className={styles.title}>What is a rotating proxy?</h1>
+          <p className={styles.lead}>
+            A rotating residential proxy routes your internet traffic through multiple real residential IP addresses. This keeps
+            your browsing private, automates IP changes, and helps prevent websites from blocking access to your requests.
+          </p>
+        </header>
+
+        <section className={styles.section}>
+          <h2 className={styles.sectionTitle}>How rotating residential proxies work</h2>
+          <p>
+            Our residential proxies offer flexible rotation options. You can let the IP change with every request, or keep the
+            same IP active for the length of a session. A session is simply a randomly generated string that locks in one IP for
+            that window of time, giving you a stable identity while the session lasts.
+          </p>
+        </section>
+
+        <section className={styles.section}>
+          <h2 className={styles.sectionTitle}>Expiration &amp; renewals</h2>
+          <ul className={styles.list}>
+            <li>
+              <strong>No extensions or renewals.</strong> Rotating residential proxies cannot be extended. Once a package
+              expires, you will need to purchase a new one.
+            </li>
+            <li>
+              <strong>Additional bandwidth.</strong> If your rotating traffic runs out, it cannot be topped up. Simply buy a new
+              package to continue working without interruptions.
+            </li>
+            <li>
+              <strong>120-day expiration.</strong> Each proxy is valid for 120 days. After that period, the proxy expires and a
+              new purchase is required.
+            </li>
+          </ul>
+        </section>
+
+        <footer className={styles.footer}>
+          <p>
+            Keep an eye on your usage to avoid unexpected service interruptions, and plan your rotations ahead of time for smooth
+            automation.
+          </p>
+        </footer>
+      </article>
+    </main>
+  );
+}

--- a/app/resources/why-residential-proxies/page.module.css
+++ b/app/resources/why-residential-proxies/page.module.css
@@ -1,0 +1,78 @@
+.page {
+  min-height: calc(100vh - 80px);
+  display: flex;
+  justify-content: center;
+  padding: 6rem 1.5rem 4rem;
+  box-sizing: border-box;
+}
+
+.article {
+  width: min(720px, 100%);
+  background: linear-gradient(160deg, rgba(34, 49, 96, 0.75), rgba(16, 24, 44, 0.9));
+  border: 1px solid rgba(124, 144, 212, 0.25);
+  border-radius: 24px;
+  padding: 3.5rem clamp(1.5rem, 4vw, 3rem);
+  color: #f4f6ff;
+  box-shadow: 0 24px 40px rgba(9, 14, 30, 0.6);
+  backdrop-filter: blur(12px);
+}
+
+.header {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.3em;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: rgba(172, 192, 255, 0.85);
+}
+
+.title {
+  margin: 0;
+  font-size: clamp(2.25rem, 4vw, 3rem);
+  line-height: 1.1;
+}
+
+.meta {
+  margin: 0;
+  font-size: 0.875rem;
+  letter-spacing: 0.02em;
+  color: rgba(214, 223, 255, 0.7);
+}
+
+.section {
+  margin-top: 2.5rem;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.sectionTitle {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #9fb6ff;
+}
+
+.section p {
+  margin: 0;
+  line-height: 1.7;
+  color: rgba(230, 234, 255, 0.9);
+}
+
+.list {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 0.75rem;
+  line-height: 1.6;
+  color: rgba(230, 234, 255, 0.92);
+}
+
+@media (max-width: 640px) {
+  .article {
+    padding: 2.5rem 1.5rem;
+  }
+}

--- a/app/resources/why-residential-proxies/page.tsx
+++ b/app/resources/why-residential-proxies/page.tsx
@@ -1,0 +1,45 @@
+import styles from "./page.module.css";
+
+export const metadata = {
+  title: "Why Residential Proxies? | SoksLine",
+  description:
+    "Understand the value of residential proxies, including stability, rotation, privacy, and affordable security for long-term projects.",
+};
+
+export default function Page() {
+  return (
+    <main className={styles.page}>
+      <article className={styles.article}>
+        <header className={styles.header}>
+          <span className={styles.eyebrow}>Guide</span>
+          <h1 className={styles.title}>Why Residential Proxies?</h1>
+          <p className={styles.meta}>12 days ago · Updated</p>
+        </header>
+
+        <section className={styles.section}>
+          <p>
+            A residential proxy is an address provided directly by your Internet Service Provider (ISP). It leverages real
+            household IPs that legitimate proxy users rely on for trusted access.
+          </p>
+          <p>
+            Residential proxies are ideal as a long-term solution for teams and operators who need consistency and stability
+            throughout their projects.
+          </p>
+        </section>
+
+        <section className={styles.section}>
+          <h2 className={styles.sectionTitle}>What residential proxies provide</h2>
+          <p>
+            Residential proxy networks deliver the core elements you need to run resilient operations without sacrificing
+            performance or privacy:
+          </p>
+          <ul className={styles.list}>
+            <li>IP rotation</li>
+            <li>Super speedy bandwidth privacy</li>
+            <li>Security for an approachable price tag</li>
+          </ul>
+        </section>
+      </article>
+    </main>
+  );
+}

--- a/components/HeaderNav.tsx
+++ b/components/HeaderNav.tsx
@@ -120,11 +120,11 @@ const NAV_CONTENT: Record<Locale, NavigationCopy> = {
               },
               {
                 label: "Why Residential Proxies?",
-                href: "https://soksline.com/blog/why-residential-proxies",
+                href: "/resources/why-residential-proxies",
               },
               {
                 label: "What is a rotating proxy?",
-                href: "https://soksline.com/blog/what-is-a-rotating-proxy",
+                href: "/resources/what-is-a-rotating-proxy",
               },
             ],
           },
@@ -228,11 +228,11 @@ const NAV_CONTENT: Record<Locale, NavigationCopy> = {
               },
               {
                 label: "Why Residential Proxies?",
-                href: "https://soksline.com/blog/why-residential-proxies",
+                href: "/resources/why-residential-proxies",
               },
               {
                 label: "What is a rotating proxy?",
-                href: "https://soksline.com/blog/what-is-a-rotating-proxy",
+                href: "/resources/what-is-a-rotating-proxy",
               },
             ],
           },


### PR DESCRIPTION
## Summary
- add an in-app resources page explaining why residential proxies are valuable
- style the new guide with gradient card layout and supporting typography
- point the navigation link to the internal resource page

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc0a4ff03c832aa9571802ed7edba3