### PR TITLE
Translate Resources section to Russian

### DIFF
--- a/app/resources/can-i-select-a-proxy-location/page.tsx
+++ b/app/resources/can-i-select-a-proxy-location/page.tsx
@@ -1,9 +1,9 @@
 import styles from "./page.module.css";
 
 export const metadata = {
-  title: "Can I select a proxy location? | SoksLine",
+  title: "Могу ли я выбрать геолокацию прокси? | SoksLine",
   description:
-    "Learn how SoksLine proxies let you choose the exact location you need across Static ISP, Static ISP IPv6, and Rotating Residential pools.",
+    "Узнайте, как прокси SoksLine позволяют выбрать нужную вам геолокацию в пулах Static ISP, Static ISP IPv6 и Rotating Residential.",
 };
 
 export default function Page() {
@@ -11,40 +11,40 @@ export default function Page() {
     <main className={styles.page}>
       <article className={styles.article}>
         <header className={styles.header}>
-          <span className={styles.eyebrow}>Guide</span>
-          <h1 className={styles.title}>Can I select a proxy location?</h1>
+          <span className={styles.eyebrow}>Справка</span>
+          <h1 className={styles.title}>Могу ли я выбрать геолокацию прокси?</h1>
           <p className={styles.lead}>
-            Yes. Every SoksLine proxy order lets you choose the location that best fits your use case. Pick the country you
-            need at checkout and tailor your traffic without extra configuration or delays.
+            Да. Каждый заказ прокси SoksLine позволяет выбрать локацию, которая лучше всего подходит под ваш сценарий.
+            Укажите нужную страну при оформлении и управляйте трафиком без дополнительной настройки и задержек.
           </p>
         </header>
 
         <section className={styles.section}>
-          <h2 className={styles.sectionTitle}>Location controls by proxy type</h2>
+          <h2 className={styles.sectionTitle}>Управление локациями по типам прокси</h2>
           <p>
-            Each proxy family gives you precise geo-targeting so you can deploy accounts, run automations, or monitor
-            campaigns in the markets that matter most to you.
+            Каждый тип прокси дает точный геотаргетинг, чтобы вы могли запускать аккаунты, автоматизацию или мониторинг
+            кампаний в нужных вам регионах.
           </p>
           <ul className={styles.list}>
             <li>
-              <strong>Static ISP proxies.</strong> Select country-level locations across our premium ISP and datacenter blend
-              for consistent uptime and low-latency scraping.
+              <strong>Static ISP прокси.</strong> Выбирайте страну в нашем премиальном пуле ISP и дата-центров для стабильной
+              работы и низкой задержки при сборе данных.
             </li>
             <li>
-              <strong>Static ISP IPv6 proxies.</strong> Choose the country you need (including state-level routing across the
-              United States) to tap into our vast IPv6 supply for high-volume tasks.
+              <strong>Static ISP IPv6 прокси.</strong> Укажите нужную страну (включая маршрутизацию по штатам в США), чтобы
+              использовать наш огромный запас IPv6 для задач с большим объемом трафика.
             </li>
             <li>
-              <strong>Rotating Residential proxies.</strong> Target countries worldwide and drill down to popular
-              states/regions for localized testing, ad verification, and automation.
+              <strong>Rotating Residential прокси.</strong> Настраивайте таргетинг на страны по всему миру и углубляйтесь до
+              популярных штатов и регионов для локализованного тестирования, проверки рекламы и автоматизации.
             </li>
           </ul>
         </section>
 
         <footer className={styles.footer}>
           <p>
-            Need a specific city or custom location mix? Message your account manager or reach us at support@soksline.com, and
-            we&apos;ll provision the routing you require.
+            Нужен конкретный город или индивидуальный набор локаций? Напишите вашему аккаунт-менеджеру или на
+            support@soksline.com — мы настроим нужную вам маршрутизацию.
           </p>
         </footer>
       </article>

--- a/app/resources/how-long-to-receive-my-ordered-proxies/page.tsx
+++ b/app/resources/how-long-to-receive-my-ordered-proxies/page.tsx
@@ -1,9 +1,9 @@
 import styles from "./page.module.css";
 
 export const metadata = {
-  title: "How long does it take to receive my ordered proxies? | SoksLine",
+  title: "Сколько времени занимает получение заказанных прокси? | SoksLine",
   description:
-    "Understand how quickly SoksLine delivers proxy orders and what happens if additional information is required for setup.",
+    "Узнайте, как быстро SoksLine поставляет прокси и что происходит, если для настройки нужна дополнительная информация.",
 };
 
 export default function Page() {
@@ -11,16 +11,15 @@ export default function Page() {
     <main className={styles.page}>
       <article className={styles.article}>
         <header className={styles.header}>
-          <span className={styles.eyebrow}>Guide</span>
-          <h1 className={styles.title}>How long does it take to receive my ordered proxies?</h1>
-          <p className={styles.meta}>11 days ago · Updated</p>
+          <span className={styles.eyebrow}>Справка</span>
+          <h1 className={styles.title}>Сколько времени занимает получение заказанных прокси?</h1>
+          <p className={styles.meta}>11 дней назад · Обновлено</p>
         </header>
 
         <section className={styles.section}>
-          <p>Proxies are delivered within 24 hours from your order payment.</p>
+          <p>Прокси доставляются в течение 24 часов после оплаты заказа.</p>
           <p>
-            In case any additional information is required from your side, a Proxy-Cheap account manager will get in touch
-            with you as soon as possible.
+            Если от вас потребуется дополнительная информация, аккаунт-менеджер Proxy-Cheap свяжется с вами как можно быстрее.
           </p>
         </section>
       </article>

--- a/app/resources/what-are-the-targeting-options-for-our-proxies/page.tsx
+++ b/app/resources/what-are-the-targeting-options-for-our-proxies/page.tsx
@@ -1,9 +1,9 @@
 import styles from "./page.module.css";
 
 export const metadata = {
-  title: "What are the targeting options for our proxies? | SoksLine",
+  title: "Какие варианты таргетинга есть у ваших прокси? | SoksLine",
   description:
-    "Explore the geo-targeting coverage for SoksLine rotating residential, static ISP, and static ISP IPv6 proxies, plus guidance on choosing the right option.",
+    "Изучите уровни геотаргетинга в пулах Rotating Residential, Static ISP и Static ISP IPv6 от SoksLine и получите советы по выбору нужного решения.",
 };
 
 function CheckBadge({ label }: { label: string }) {
@@ -33,30 +33,30 @@ export default function Page() {
     <main className={styles.page}>
       <article className={styles.article}>
         <header className={styles.header}>
-          <span className={styles.eyebrow}>Guide</span>
-          <h1 className={styles.title}>What are the targeting options for our proxies?</h1>
+          <span className={styles.eyebrow}>Справка</span>
+          <h1 className={styles.title}>Какие варианты таргетинга есть у ваших прокси?</h1>
           <p className={styles.lead}>
-            Choose the best targeting level for your workflow across the rotating residential, Static ISP, and Static ISP IPv6
-            pools we provide at SoksLine.
+            Подберите уровень таргетинга, который лучше всего подходит для вашей задачи, в пулах Rotating Residential, Static
+            ISP и Static ISP IPv6 от SoksLine.
           </p>
         </header>
 
         <section className={styles.section}>
-          <h2 className={styles.sectionTitle}>Geo-targeting coverage</h2>
+          <h2 className={styles.sectionTitle}>Возможности геотаргетинга</h2>
           <p>
-            The matrix below outlines the available targeting depth for each proxy type we offer. We focus on residential-grade
-            access, so the list is limited to the options you can purchase from SoksLine today.
+            Таблица ниже показывает глубину таргетинга для каждого типа прокси. Мы сосредоточены на резидентских решениях,
+            поэтому перечислены только доступные сегодня варианты от SoksLine.
           </p>
 
           <div className={styles.tableWrapper}>
             <table className={styles.table}>
               <thead>
                 <tr>
-                  <th scope="col">Proxy type</th>
-                  <th scope="col">Country</th>
-                  <th scope="col">Region / State</th>
-                  <th scope="col">City</th>
-                  <th scope="col">ISP / Carrier</th>
+                  <th scope="col">Тип прокси</th>
+                  <th scope="col">Страна</th>
+                  <th scope="col">Регион / Штат</th>
+                  <th scope="col">Город</th>
+                  <th scope="col">Провайдер / Оператор</th>
                 </tr>
               </thead>
               <tbody>
@@ -65,16 +65,16 @@ export default function Page() {
                     Rotating Residential
                   </th>
                   <td className={styles.checkCell}>
-                    <CheckBadge label="Country-level targeting available" />
+                    <CheckBadge label="Доступен таргетинг на уровне страны" />
                   </td>
                   <td className={styles.checkCell}>
-                    <CheckBadge label="Region-level targeting available" />
+                    <CheckBadge label="Доступен таргетинг на уровне региона" />
                   </td>
                   <td className={styles.checkCell}>
-                    <CheckBadge label="City-level targeting available" />
+                    <CheckBadge label="Доступен таргетинг на уровне города" />
                   </td>
                   <td className={styles.checkCell}>
-                    <CheckBadge label="ISP and carrier targeting available" />
+                    <CheckBadge label="Доступен таргетинг по провайдерам" />
                   </td>
                 </tr>
                 <tr>
@@ -82,16 +82,16 @@ export default function Page() {
                     Static ISP
                   </th>
                   <td className={styles.checkCell}>
-                    <CheckBadge label="Country-level targeting available" />
+                    <CheckBadge label="Доступен таргетинг на уровне страны" />
                   </td>
                   <td className={styles.checkCell}>
-                    <CheckBadge label="Region-level targeting available" />
+                    <CheckBadge label="Доступен таргетинг на уровне региона" />
                   </td>
                   <td className={styles.checkCell}>
-                    <CheckBadge label="City-level targeting available" />
+                    <CheckBadge label="Доступен таргетинг на уровне города" />
                   </td>
                   <td className={styles.checkCell}>
-                    <CrossBadge label="ISP targeting not supported" />
+                    <CrossBadge label="Таргетинг по провайдерам не поддерживается" />
                   </td>
                 </tr>
                 <tr>
@@ -99,16 +99,16 @@ export default function Page() {
                     Static ISP IPv6
                   </th>
                   <td className={styles.checkCell}>
-                    <CheckBadge label="Country-level targeting available" />
+                    <CheckBadge label="Доступен таргетинг на уровне страны" />
                   </td>
                   <td className={styles.checkCell}>
-                    <CrossBadge label="Region targeting not supported" />
+                    <CrossBadge label="Таргетинг по регионам не поддерживается" />
                   </td>
                   <td className={styles.checkCell}>
-                    <CrossBadge label="City targeting not supported" />
+                    <CrossBadge label="Таргетинг по городам не поддерживается" />
                   </td>
                   <td className={styles.checkCell}>
-                    <CrossBadge label="ISP targeting not supported" />
+                    <CrossBadge label="Таргетинг по провайдерам не поддерживается" />
                   </td>
                 </tr>
               </tbody>
@@ -117,28 +117,27 @@ export default function Page() {
         </section>
 
         <section className={styles.section}>
-          <h2 className={styles.sectionTitle}>How to pick the right targeting level</h2>
+          <h2 className={styles.sectionTitle}>Как выбрать подходящий уровень таргетинга</h2>
           <ul className={styles.list}>
             <li>
-              <strong>Rotating Residential</strong> delivers the most granular controls. Choose this pool when you need to lock
-              sessions to a specific metro area or carrier for localized SEO, user experience testing, or ad verification.
+              <strong>Rotating Residential</strong> дает самые гибкие настройки. Выбирайте этот пул, если нужно закрепить сессии
+              за определённым городом или провайдером для локального SEO, тестирования UX или проверки рекламы.
             </li>
             <li>
-              <strong>Static ISP</strong> covers the same cities and regions as our rotating pool, but keeps a single IP tied to
-              your project. It&apos;s ideal for long-running automations, e-commerce operations, or account management tasks that
-              must retain a consistent identity.
+              <strong>Static ISP</strong> охватывает те же города и регионы, что и ротационный пул, но сохраняет один IP за вашим
+              проектом. Идеально для долгих автоматизаций, e-commerce и управления аккаунтами, где важна постоянная идентичность.
             </li>
             <li>
-              <strong>Static ISP IPv6</strong> is perfect for projects that only require national presence at massive scale. Use it
-              when you want affordable U.S. coverage without needing specific municipalities or carriers.
+              <strong>Static ISP IPv6</strong> подходит проектам, которым нужна только национальная представленность в большом
+              масштабе. Используйте его, когда нужен недорогой охват по США без привязки к конкретным городам или провайдерам.
             </li>
           </ul>
         </section>
 
         <section className={styles.section}>
           <p className={styles.note}>
-            Need help matching your use case to the right pool? Reach out to your account manager or the SoksLine support team
-            and we&apos;ll recommend the best option based on your targeting requirements.
+            Нужна помощь с выбором подходящего пула? Свяжитесь с вашим аккаунт-менеджером или командой поддержки SoksLine — мы
+            предложим оптимальное решение с учётом ваших требований к таргетингу.
           </p>
         </section>
       </article>

--- a/app/resources/what-is-a-rotating-proxy/page.tsx
+++ b/app/resources/what-is-a-rotating-proxy/page.tsx
@@ -1,9 +1,9 @@
 import styles from "./page.module.css";
 
 export const metadata = {
-  title: "What is a Rotating Proxy? | SoksLine",
+  title: "Что такое ротационный прокси? | SoksLine",
   description:
-    "Learn what rotating residential proxies are, how sessions work, and what to expect from expiration and renewals at SoksLine.",
+    "Узнайте, что такое ротационные резидентские прокси, как работают сессии и что ожидать от сроков действия и продлений в SoksLine.",
 };
 
 export default function Page() {
@@ -11,45 +11,45 @@ export default function Page() {
     <main className={styles.page}>
       <article className={styles.article}>
         <header className={styles.header}>
-          <span className={styles.eyebrow}>Guide</span>
-          <h1 className={styles.title}>What is a rotating proxy?</h1>
+          <span className={styles.eyebrow}>Справка</span>
+          <h1 className={styles.title}>Что такое ротационный прокси?</h1>
           <p className={styles.lead}>
-            A rotating residential proxy routes your internet traffic through multiple real residential IP addresses. This keeps
-            your browsing private, automates IP changes, and helps prevent websites from blocking access to your requests.
+            Ротационный резидентский прокси направляет ваш трафик через несколько реальных домашних IP-адресов. Это сохраняет
+            приватность, автоматизирует смену IP и помогает избежать блокировок со стороны сайтов.
           </p>
         </header>
 
         <section className={styles.section}>
-          <h2 className={styles.sectionTitle}>How rotating residential proxies work</h2>
+          <h2 className={styles.sectionTitle}>Как работают ротационные резидентские прокси</h2>
           <p>
-            Our residential proxies offer flexible rotation options. You can let the IP change with every request, or keep the
-            same IP active for the length of a session. A session is simply a randomly generated string that locks in one IP for
-            that window of time, giving you a stable identity while the session lasts.
+            Наши резидентские прокси предлагают гибкие варианты ротации. IP может меняться с каждым запросом или оставаться
+            неизменным на протяжении всей сессии. Сессия — это случайно сгенерированная строка, которая закрепляет один IP на
+            выбранный период, обеспечивая стабильную идентичность, пока сессия активна.
           </p>
         </section>
 
         <section className={styles.section}>
-          <h2 className={styles.sectionTitle}>Expiration &amp; renewals</h2>
+          <h2 className={styles.sectionTitle}>Срок действия и продления</h2>
           <ul className={styles.list}>
             <li>
-              <strong>No extensions or renewals.</strong> Rotating residential proxies cannot be extended. Once a package
-              expires, you will need to purchase a new one.
+              <strong>Без продлений.</strong> Ротационные резидентские прокси нельзя продлить. После окончания срока действия
+              пакета необходимо оформить новый.
             </li>
             <li>
-              <strong>Additional bandwidth.</strong> If your rotating traffic runs out, it cannot be topped up. Simply buy a new
-              package to continue working without interruptions.
+              <strong>Дополнительный трафик.</strong> Если израсходован весь трафик, пополнить его нельзя. Купите новый пакет,
+              чтобы продолжить работу без пауз.
             </li>
             <li>
-              <strong>120-day expiration.</strong> Each proxy is valid for 120 days. After that period, the proxy expires and a
-              new purchase is required.
+              <strong>Срок 120 дней.</strong> Каждый прокси действует 120 дней. По истечении этого времени он деактивируется и
+              требуется новая покупка.
             </li>
           </ul>
         </section>
 
         <footer className={styles.footer}>
           <p>
-            Keep an eye on your usage to avoid unexpected service interruptions, and plan your rotations ahead of time for smooth
-            automation.
+            Следите за потреблением, чтобы избежать неожиданных перерывов в работе, и планируйте ротации заранее для плавной
+            автоматизации.
           </p>
         </footer>
       </article>

--- a/app/resources/what-solutions-do-you-offer/page.tsx
+++ b/app/resources/what-solutions-do-you-offer/page.tsx
@@ -1,9 +1,9 @@
 import styles from "./page.module.css";
 
 export const metadata = {
-  title: "What solutions do you offer? | SoksLine",
+  title: "Какие решения вы предлагаете? | SoksLine",
   description:
-    "Discover the proxy solutions SoksLine provides, including static ISP, IPv6 ISP, and rotating residential networks tailored to your workflows.",
+    "Узнайте о решениях SoksLine: статических ISP, IPv6 ISP и ротационных резидентских сетях, адаптированных под ваши рабочие процессы.",
 };
 
 export default function Page() {
@@ -11,29 +11,29 @@ export default function Page() {
     <main className={styles.page}>
       <article className={styles.article}>
         <header className={styles.header}>
-          <span className={styles.eyebrow}>Guide</span>
-          <h1 className={styles.title}>What solutions do you offer?</h1>
-          <p className={styles.meta}>12 days ago · Updated</p>
+          <span className={styles.eyebrow}>Справка</span>
+          <h1 className={styles.title}>Какие решения вы предлагаете?</h1>
+          <p className={styles.meta}>12 дней назад · Обновлено</p>
         </header>
 
         <section className={styles.section}>
           <p>
-            At SoksLine, we pair every customer with proxy solutions that keep critical workflows online and compliant, no
-            matter the scale of their projects.
+            В SoksLine мы подбираем каждому клиенту решения, которые обеспечивают бесперебойную и легальную работу ключевых
+            процессов вне зависимости от масштаба проекта.
           </p>
-          <p>Here&apos;s the lineup of services available today:</p>
+          <p>Вот какие услуги доступны уже сейчас:</p>
           <ul className={styles.list}>
             <li>
-              <strong>Static ISP</strong> — dedicated ISP IPs with datacenter-grade reliability for automation, traffic
-              management, and verified browsing.
+              <strong>Static ISP</strong> — выделенные ISP-IP с надежностью дата-центров для автоматизации, управления трафиком
+              и безопасного серфинга.
             </li>
             <li>
-              <strong>Static ISP IPv6</strong> — massive U.S. IPv6 ranges powered by ISP carriers for bandwidth-heavy tasks
-              that demand unique addresses.
+              <strong>Static ISP IPv6</strong> — огромные диапазоны IPv6 из США на базе ISP-провайдеров для задач с высоким
+              потреблением трафика и уникальными адресами.
             </li>
             <li>
-              <strong>Rotating Residential</strong> — ethically sourced household connections that refresh on demand to power
-              geo-targeted research and multi-account operations.
+              <strong>Rotating Residential</strong> — этичные жилые подключения с автоматической сменой IP для геотаргетинга,
+              исследований и мультиаккаунтных операций.
             </li>
           </ul>
         </section>

--- a/app/resources/why-residential-proxies/page.tsx
+++ b/app/resources/why-residential-proxies/page.tsx
@@ -1,9 +1,9 @@
 import styles from "./page.module.css";
 
 export const metadata = {
-  title: "Why Residential Proxies? | SoksLine",
+  title: "Зачем нужны резидентские прокси? | SoksLine",
   description:
-    "Understand the value of residential proxies, including stability, rotation, privacy, and affordable security for long-term projects.",
+    "Разберитесь, какие преимущества дают резидентские прокси: стабильность, ротацию, приватность и доступную защиту для долгосрочных проектов.",
 };
 
 export default function Page() {
@@ -11,32 +11,32 @@ export default function Page() {
     <main className={styles.page}>
       <article className={styles.article}>
         <header className={styles.header}>
-          <span className={styles.eyebrow}>Guide</span>
-          <h1 className={styles.title}>Why Residential Proxies?</h1>
-          <p className={styles.meta}>12 days ago · Updated</p>
+          <span className={styles.eyebrow}>Справка</span>
+          <h1 className={styles.title}>Зачем нужны резидентские прокси?</h1>
+          <p className={styles.meta}>12 дней назад · Обновлено</p>
         </header>
 
         <section className={styles.section}>
           <p>
-            A residential proxy is an address provided directly by your Internet Service Provider (ISP). It leverages real
-            household IPs that legitimate proxy users rely on for trusted access.
+            Резидентский прокси — это адрес, который предоставляет ваш интернет-провайдер (ISP). Это реальные домашние IP,
+            на которые полагаются легальные пользователи прокси для надежного доступа.
           </p>
           <p>
-            Residential proxies are ideal as a long-term solution for teams and operators who need consistency and stability
-            throughout their projects.
+            Такие прокси идеально подходят как долгосрочное решение для команд и специалистов, которым важны стабильность и
+            предсказуемость на протяжении всего проекта.
           </p>
         </section>
 
         <section className={styles.section}>
-          <h2 className={styles.sectionTitle}>What residential proxies provide</h2>
+          <h2 className={styles.sectionTitle}>Что дают резидентские прокси</h2>
           <p>
-            Residential proxy networks deliver the core elements you need to run resilient operations without sacrificing
-            performance or privacy:
+            Сети резидентских прокси обеспечивают ключевые элементы для устойчивой работы без ущерба для скорости и
+            приватности:
           </p>
           <ul className={styles.list}>
-            <li>IP rotation</li>
-            <li>Super speedy bandwidth privacy</li>
-            <li>Security for an approachable price tag</li>
+            <li>Ротацию IP</li>
+            <li>Высокую скорость при сохранении приватности</li>
+            <li>Защиту по доступной цене</li>
           </ul>
         </section>
       </article>

--- a/components/HeaderNav.tsx
+++ b/components/HeaderNav.tsx
@@ -99,15 +99,15 @@ const NAV_CONTENT: Record<Locale, NavigationCopy> = {
             heading: "Ресурсы",
             items: [
               {
-                label: "Can I select a proxy location?",
+                label: "Могу ли я выбрать геолокацию прокси?",
                 href: "/resources/can-i-select-a-proxy-location",
               },
               {
-                label: "What are the targeting options for our proxies?",
+                label: "Какие варианты таргетинга есть у ваших прокси?",
                 href: "/resources/what-are-the-targeting-options-for-our-proxies",
               },
               {
-                label: "What solutions do you offer?",
+                label: "Какие решения вы предлагаете?",
                 href: "/resources/what-solutions-do-you-offer",
               },
             ],
@@ -115,15 +115,15 @@ const NAV_CONTENT: Record<Locale, NavigationCopy> = {
           {
             items: [
               {
-                label: "How long does it take to receive my ordered proxies?",
+                label: "Сколько времени занимает получение заказанных прокси?",
                 href: "/resources/how-long-to-receive-my-ordered-proxies",
               },
               {
-                label: "Why Residential Proxies?",
+                label: "Зачем нужны резидентские прокси?",
                 href: "/resources/why-residential-proxies",
               },
               {
-                label: "What is a rotating proxy?",
+                label: "Что такое ротационный прокси?",
                 href: "/resources/what-is-a-rotating-proxy",
               },
             ],


### PR DESCRIPTION
## Summary
- translated the Resources navigation labels for the Russian locale
- localized all Resources guide pages with Russian titles, metadata, and body content

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68dc1c615470832ab3a250d196885fd0