### PR TITLE
Add Help Center page and update navigation link

### DIFF
--- a/app/help-center/HelpCenterPage.tsx
+++ b/app/help-center/HelpCenterPage.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { ChangeEvent, useMemo, useState } from "react";
+
+import { useLocale } from "../../components/LocaleContext";
+import type { Locale } from "../../components/LocaleContext";
+
+import styles from "./page.module.css";
+
+type HelpCenterCopy = {
+  title: string;
+  description: string;
+  requiredNote: string;
+  email: {
+    label: string;
+    placeholder: string;
+  };
+  descriptionField: {
+    label: string;
+    placeholder: string;
+  };
+  attachments: {
+    label: string;
+    helper: string;
+  };
+  submitLabel: string;
+};
+
+const HELP_CENTER_COPY: Record<Locale, HelpCenterCopy> = {
+  en: {
+    title: "Contact Us",
+    description:
+      "Let us know how we can help. A member of our support staff will respond as soon as possible.",
+    requiredNote: "Fields marked with an asterisk (*) are required.",
+    email: {
+      label: "Your email address*",
+      placeholder: "name@example.com",
+    },
+    descriptionField: {
+      label: "Description*",
+      placeholder: "Please enter the details of your request.",
+    },
+    attachments: {
+      label: "Attachments",
+      helper: "Choose a file or drag and drop here",
+    },
+    submitLabel: "Submit",
+  },
+  ru: {
+    title: "Свяжитесь с нами",
+    description:
+      "Опишите, с чем нужна помощь. Команда поддержки ответит вам как можно быстрее.",
+    requiredNote: "Поля, отмеченные звёздочкой (*), обязательны для заполнения.",
+    email: {
+      label: "Ваш e-mail*",
+      placeholder: "name@example.com",
+    },
+    descriptionField: {
+      label: "Описание*",
+      placeholder: "Опишите детали запроса",
+    },
+    attachments: {
+      label: "Вложения",
+      helper: "Выберите файл или перетащите его сюда",
+    },
+    submitLabel: "Отправить",
+  },
+};
+
+export default function HelpCenterPage() {
+  const { locale } = useLocale();
+  const copy = HELP_CENTER_COPY[locale];
+  const [fileLabel, setFileLabel] = useState<string | null>(null);
+
+  const attachmentText = useMemo(() => fileLabel ?? copy.attachments.helper, [copy.attachments.helper, fileLabel]);
+
+  const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const files = event.target.files;
+    if (!files || files.length === 0) {
+      setFileLabel(null);
+      return;
+    }
+
+    const names = Array.from(files)
+      .map(file => file.name)
+      .slice(0, 3);
+
+    const formatted = files.length > 3 ? `${names.join(", ")} +${files.length - 3}` : names.join(", ");
+    setFileLabel(formatted);
+  };
+
+  return (
+    <main className={styles.page}>
+      <section className={styles.panel} aria-labelledby="help-center-title">
+        <header className={styles.header}>
+          <h1 id="help-center-title" className={styles.title}>
+            {copy.title}
+          </h1>
+          <p className={styles.description}>{copy.description}</p>
+          <p className={styles.note}>{copy.requiredNote}</p>
+        </header>
+
+        <form className={styles.form}>
+          <div className={styles.field}>
+            <label className={styles.label} htmlFor="contact-email">
+              {copy.email.label}
+            </label>
+            <input
+              id="contact-email"
+              name="email"
+              type="email"
+              required
+              className={styles.input}
+              placeholder={copy.email.placeholder}
+            />
+          </div>
+
+          <div className={styles.field}>
+            <label className={styles.label} htmlFor="contact-description">
+              {copy.descriptionField.label}
+            </label>
+            <textarea
+              id="contact-description"
+              name="description"
+              required
+              className={`${styles.input} ${styles.textarea}`}
+              placeholder={copy.descriptionField.placeholder}
+              rows={8}
+            />
+          </div>
+
+          <div className={styles.field}>
+            <span className={styles.label}>{copy.attachments.label}</span>
+            <label className={styles.dropzone} htmlFor="contact-attachments">
+              <input
+                id="contact-attachments"
+                name="attachments"
+                type="file"
+                className={styles.fileInput}
+                multiple
+                onChange={handleFileChange}
+              />
+              <span>{attachmentText}</span>
+            </label>
+          </div>
+
+          <button type="submit" className={styles.submit}>
+            {copy.submitLabel}
+          </button>
+        </form>
+      </section>
+    </main>
+  );
+}

--- a/app/help-center/page.module.css
+++ b/app/help-center/page.module.css
@@ -1,0 +1,163 @@
+.page {
+  min-height: calc(100vh - 72px);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 96px 16px 120px;
+  background: linear-gradient(180deg, rgba(11, 18, 32, 0.92) 0%, rgba(11, 18, 32, 0.98) 60%, #05070f 100%);
+}
+
+.panel {
+  width: 100%;
+  max-width: 720px;
+  background: #ffffff;
+  border-radius: 24px;
+  box-shadow: 0 30px 70px rgba(5, 14, 36, 0.35);
+  padding: 48px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.title {
+  margin: 0;
+  font-size: 36px;
+  line-height: 1.1;
+  color: #0b1220;
+}
+
+.description {
+  margin: 0;
+  color: #3a4564;
+  font-size: 18px;
+  line-height: 1.6;
+}
+
+.note {
+  margin: 0;
+  font-size: 14px;
+  color: #5a6b8a;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.label {
+  font-weight: 600;
+  font-size: 15px;
+  color: #101935;
+}
+
+.input {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid #d8def0;
+  padding: 14px 16px;
+  font-size: 16px;
+  line-height: 1.5;
+  color: #0b1220;
+  background-color: #f8faff;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.input:focus {
+  outline: none;
+  border-color: #3c6df0;
+  box-shadow: 0 0 0 4px rgba(60, 109, 240, 0.15);
+}
+
+.textarea {
+  min-height: 200px;
+  resize: vertical;
+}
+
+.dropzone {
+  border: 2px dashed #c6d2f2;
+  border-radius: 16px;
+  padding: 28px 24px;
+  text-align: center;
+  color: #3a4564;
+  font-size: 15px;
+  cursor: pointer;
+  background: #f8faff;
+  transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.dropzone:hover,
+.dropzone:focus-within {
+  border-color: #3c6df0;
+  background: #eef3ff;
+}
+
+.fileInput {
+  display: none;
+}
+
+.submit {
+  align-self: flex-start;
+  border: none;
+  border-radius: 12px;
+  background: linear-gradient(135deg, #486bff 0%, #2330ff 100%);
+  color: #ffffff;
+  font-size: 16px;
+  font-weight: 600;
+  padding: 14px 32px;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.submit:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 30px rgba(35, 48, 255, 0.25);
+}
+
+.submit:focus {
+  outline: none;
+  box-shadow: 0 0 0 4px rgba(35, 48, 255, 0.2);
+}
+
+@media (max-width: 768px) {
+  .page {
+    padding: 72px 16px 96px;
+  }
+
+  .panel {
+    padding: 32px;
+    border-radius: 20px;
+  }
+
+  .title {
+    font-size: 30px;
+  }
+}
+
+@media (max-width: 480px) {
+  .panel {
+    padding: 28px 20px;
+    border-radius: 18px;
+  }
+
+  .title {
+    font-size: 26px;
+  }
+
+  .submit {
+    width: 100%;
+    text-align: center;
+  }
+}

--- a/app/help-center/page.tsx
+++ b/app/help-center/page.tsx
@@ -1,0 +1,10 @@
+import HelpCenterPage from "./HelpCenterPage";
+
+export const metadata = {
+  title: "Help Center | SoksLine",
+  description: "Reach out to the SoksLine support team for assistance.",
+};
+
+export default function Page() {
+  return <HelpCenterPage />;
+}

--- a/components/HeaderNav.tsx
+++ b/components/HeaderNav.tsx
@@ -138,7 +138,7 @@ const NAV_CONTENT: Record<Locale, NavigationCopy> = {
         ],
       },
     ],
-    auxLinks: [{ label: "Инфоцентр", href: "https://soksline.com/support" }],
+    auxLinks: [{ label: "Техподдержка", href: "/help-center" }],
   },
   en: {
     navLabel: "Primary navigation",
@@ -246,7 +246,7 @@ const NAV_CONTENT: Record<Locale, NavigationCopy> = {
         ],
       },
     ],
-    auxLinks: [{ label: "Help Center", href: "https://soksline.com/support" }],
+    auxLinks: [{ label: "Help Center", href: "/help-center" }],
   },
 };
 


### PR DESCRIPTION
## Summary
- add a localized Help Center contact page with a styled support request form
- point the Help Center navigation item to the new internal route and update the Russian label

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc322ce70c832a9ef83dc0a2f72758