### PR TITLE
Add configurable order page and route CTAs to it

### DIFF
--- a/app/order/OrderConfigurator.tsx
+++ b/app/order/OrderConfigurator.tsx
@@ -1,0 +1,383 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { useLocale } from "../../components/LocaleContext";
+import { ORDER_PAGE, type OrderService } from "../../lib/order";
+import styles from "./page.module.css";
+
+function findService(services: OrderService[], id?: string) {
+  if (!services.length) {
+    return undefined;
+  }
+
+  if (!id) {
+    return services[0];
+  }
+
+  return services.find(service => service.id === id) ?? services[0];
+}
+
+function findOption<T extends { id: string }>(options: T[], id?: string, fallbackId?: string) {
+  if (!options.length) {
+    return undefined;
+  }
+
+  if (id) {
+    const match = options.find(option => option.id === id);
+    if (match) {
+      return match;
+    }
+  }
+
+  if (fallbackId) {
+    const match = options.find(option => option.id === fallbackId);
+    if (match) {
+      return match;
+    }
+  }
+
+  return options[0];
+}
+
+function formatCurrency(amount: number, locale: string, currency: string) {
+  const formatter = new Intl.NumberFormat(locale === "ru" ? "ru-RU" : "en-US", {
+    style: "currency",
+    currency,
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+
+  return formatter.format(amount);
+}
+
+export default function OrderConfigurator() {
+  const { locale } = useLocale();
+  const copy = ORDER_PAGE[locale];
+  const searchParams = useSearchParams();
+
+  const serviceParam = searchParams.get("service") ?? undefined;
+  const planParam = searchParams.get("plan") ?? undefined;
+  const durationParam = searchParams.get("duration") ?? undefined;
+  const locationParam = searchParams.get("location") ?? undefined;
+  const ispParam = searchParams.get("isp") ?? undefined;
+  const autoRenewParam = searchParams.get("autoRenew") ?? undefined;
+
+  const initialService = useMemo(() => findService(copy.services, serviceParam), [copy.services, serviceParam]);
+  const [serviceId, setServiceId] = useState(initialService?.id ?? "");
+
+  useEffect(() => {
+    setServiceId(initialService?.id ?? "");
+  }, [initialService?.id]);
+
+  const service = useMemo(() => findService(copy.services, serviceId), [copy.services, serviceId]);
+
+  const initialPlan = useMemo(() => {
+    if (!service) {
+      return undefined;
+    }
+
+    return findOption(service.plans, planParam, service.defaultPlanId);
+  }, [service, planParam]);
+
+  const [planId, setPlanId] = useState(initialPlan?.id ?? "");
+
+  useEffect(() => {
+    setPlanId(initialPlan?.id ?? "");
+  }, [initialPlan?.id, service?.id]);
+
+  const initialDuration = useMemo(() => {
+    if (!service) {
+      return undefined;
+    }
+
+    return findOption(service.durations, durationParam, service.durations[0]?.id);
+  }, [service, durationParam]);
+
+  const [durationId, setDurationId] = useState(initialDuration?.id ?? "");
+
+  useEffect(() => {
+    setDurationId(initialDuration?.id ?? "");
+  }, [initialDuration?.id, service?.id]);
+
+  const initialLocation = useMemo(() => {
+    if (!service) {
+      return undefined;
+    }
+
+    return findOption(service.locations, locationParam);
+  }, [service, locationParam]);
+
+  const [locationId, setLocationId] = useState(initialLocation?.id ?? service?.locations[0]?.id ?? "");
+
+  useEffect(() => {
+    setLocationId(initialLocation?.id ?? service?.locations[0]?.id ?? "");
+  }, [initialLocation?.id, service?.id, service?.locations]);
+
+  const initialIsp = useMemo(() => {
+    if (!service) {
+      return undefined;
+    }
+
+    return findOption(service.ispOptions, ispParam);
+  }, [service, ispParam]);
+
+  const [ispId, setIspId] = useState(initialIsp?.id ?? service?.ispOptions[0]?.id ?? "");
+
+  useEffect(() => {
+    setIspId(initialIsp?.id ?? service?.ispOptions[0]?.id ?? "");
+  }, [initialIsp?.id, service?.id, service?.ispOptions]);
+
+  const [autoRenew, setAutoRenew] = useState(() => autoRenewParam !== "false");
+
+  useEffect(() => {
+    if (autoRenewParam === undefined) {
+      return;
+    }
+
+    setAutoRenew(autoRenewParam !== "false" && autoRenewParam !== "0");
+  }, [autoRenewParam]);
+
+  const plan = service?.plans.find(item => item.id === planId) ?? service?.plans[0];
+  const duration = service?.durations.find(item => item.id === durationId) ?? service?.durations[0];
+  const location = service?.locations.find(item => item.id === locationId);
+  const isp = service?.ispOptions.find(item => item.id === ispId);
+
+  const totalAmount = plan && duration ? plan.priceAmount * duration.multiplier : 0;
+  const formattedPlanPrice = plan ? formatCurrency(plan.priceAmount, locale, service?.currency ?? "USD") : "";
+  const formattedTotal = formatCurrency(totalAmount, locale, service?.currency ?? "USD");
+
+  return (
+    <main className={styles.page}>
+      <div className={styles.inner}>
+        <div className={styles.leftColumn}>
+          <section className={styles.card}>
+            <h1 className={styles.heroTitle}>{copy.title}</h1>
+            <p className={styles.heroSubtitle}>{copy.subtitle}</p>
+          </section>
+
+          <section className={styles.card}>
+            <header className={styles.sectionHeader}>
+              <h2 className={styles.sectionTitle}>{copy.serviceSectionTitle}</h2>
+              <p className={styles.sectionSubtitle}>{copy.serviceSectionSubtitle}</p>
+            </header>
+
+            <div className={styles.serviceCards}>
+              {copy.services.map(option => {
+                const isActive = option.id === service?.id;
+                return (
+                  <button
+                    key={option.id}
+                    type="button"
+                    className={`${styles.serviceCard} ${isActive ? styles.serviceCardActive : ""}`.trim()}
+                    onClick={() => setServiceId(option.id)}
+                    aria-pressed={isActive}
+                  >
+                    {option.badge && <span className={styles.serviceBadge}>{option.badge}</span>}
+                    <h3 className={styles.serviceName}>{option.name}</h3>
+                    <p className={styles.serviceHeadline}>{option.headline}</p>
+                    <p className={styles.servicePrice}>{option.priceHint}</p>
+                    <ul className={styles.serviceHighlights}>
+                      {option.highlights.map(highlight => (
+                        <li key={highlight}>{highlight}</li>
+                      ))}
+                    </ul>
+                  </button>
+                );
+              })}
+            </div>
+          </section>
+
+          {service && service.plans.length > 0 && (
+            <section className={styles.card}>
+              <header className={styles.sectionHeader}>
+                <h2 className={styles.sectionTitle}>{copy.planSectionTitle}</h2>
+                <p className={styles.sectionSubtitle}>{copy.planSectionSubtitle}</p>
+              </header>
+
+              <div className={styles.planGrid}>
+                {service.plans.map(option => {
+                  const isActive = option.id === plan?.id;
+                  const price = formatCurrency(option.priceAmount, locale, service.currency);
+                  return (
+                    <button
+                      key={option.id}
+                      type="button"
+                      className={`${styles.planCard} ${isActive ? styles.planCardActive : ""}`.trim()}
+                      onClick={() => setPlanId(option.id)}
+                      aria-pressed={isActive}
+                    >
+                      <div>
+                        <h3 className={styles.planName}>{option.name}</h3>
+                        <p className={styles.planPrice}>
+                          <span>{price}</span>
+                          <span className={styles.planPriceSuffix}>{option.priceSuffix}</span>
+                        </p>
+                      </div>
+                      <p className={styles.planSummary}>{option.summary}</p>
+                      <ul className={styles.planFeatures}>
+                        {option.features.map(feature => (
+                          <li key={feature}>{feature}</li>
+                        ))}
+                      </ul>
+                    </button>
+                  );
+                })}
+              </div>
+            </section>
+          )}
+
+          {service && (
+            <section className={styles.card}>
+              <header className={styles.sectionHeader}>
+                <h2 className={styles.sectionTitle}>{copy.locationSectionTitle}</h2>
+                <p className={styles.sectionSubtitle}>{copy.locationSectionSubtitle}</p>
+              </header>
+
+              <div className={styles.selectGroup}>
+                <div className={styles.selectWrapper}>
+                  <label className={styles.selectLabel} htmlFor="order-location">
+                    {copy.locationSectionTitle}
+                  </label>
+                  <select
+                    id="order-location"
+                    className={styles.select}
+                    value={location?.id ?? ""}
+                    onChange={event => setLocationId(event.target.value)}
+                  >
+                    {service.locations.map(option => (
+                      <option key={option.id} value={option.id}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div className={styles.selectWrapper}>
+                  <label className={styles.selectLabel} htmlFor="order-isp">
+                    {copy.ispSectionTitle}
+                  </label>
+                  <select
+                    id="order-isp"
+                    className={styles.select}
+                    value={isp?.id ?? ""}
+                    onChange={event => setIspId(event.target.value)}
+                  >
+                    {service.ispOptions.map(option => (
+                      <option key={option.id} value={option.id}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                  <p className={styles.selectHelp}>{copy.ispSectionSubtitle}</p>
+                </div>
+              </div>
+            </section>
+          )}
+
+          {service && service.durations.length > 0 && (
+            <section className={styles.card}>
+              <header className={styles.sectionHeader}>
+                <h2 className={styles.sectionTitle}>{copy.durationSectionTitle}</h2>
+                <p className={styles.sectionSubtitle}>{copy.durationSectionSubtitle}</p>
+              </header>
+
+              <div className={styles.durationChips}>
+                {service.durations.map(option => {
+                  const isActive = option.id === duration?.id;
+                  return (
+                    <button
+                      key={option.id}
+                      type="button"
+                      className={`${styles.durationButton} ${isActive ? styles.durationButtonActive : ""}`.trim()}
+                      onClick={() => setDurationId(option.id)}
+                      aria-pressed={isActive}
+                    >
+                      <span>{option.label}</span>
+                      {option.description && (
+                        <span className={styles.durationDescription}>{option.description}</span>
+                      )}
+                    </button>
+                  );
+                })}
+              </div>
+            </section>
+          )}
+
+          <section className={styles.card}>
+            <div className={styles.toggleRow}>
+              <label className={styles.toggleSwitch}>
+                <input
+                  type="checkbox"
+                  className={styles.toggleInput}
+                  checked={autoRenew}
+                  onChange={event => setAutoRenew(event.target.checked)}
+                  aria-label={copy.autoRenewLabel}
+                />
+                <span className={styles.toggleSlider} aria-hidden="true" />
+              </label>
+              <div className={styles.toggleDescription}>
+                <p className={styles.toggleTitle}>{copy.autoRenewLabel}</p>
+                <p className={styles.toggleText}>{copy.autoRenewDescription}</p>
+                <p className={styles.autoRenewState}>{autoRenew ? copy.summaryAutoRenewOn : copy.summaryAutoRenewOff}</p>
+              </div>
+            </div>
+          </section>
+        </div>
+
+        <aside className={`${styles.card} ${styles.summaryCard}`}>
+          <h2 className={styles.summaryTitle}>{copy.summaryTitle}</h2>
+          <ul className={styles.summaryList}>
+            <li>
+              <p className={styles.summaryItemTitle}>{copy.summaryServiceLabel}</p>
+              <p className={styles.summaryItemValue}>{service?.name}</p>
+            </li>
+            <li>
+              <p className={styles.summaryItemTitle}>{copy.summaryPlanLabel}</p>
+              <p className={styles.summaryItemValue}>{plan?.name}</p>
+            </li>
+            <li>
+              <p className={styles.summaryItemTitle}>{copy.summaryLocationLabel}</p>
+              <p className={styles.summaryItemValue}>{location?.label}</p>
+            </li>
+            <li>
+              <p className={styles.summaryItemTitle}>{copy.summaryIspLabel}</p>
+              <p className={styles.summaryItemValue}>{isp?.label}</p>
+            </li>
+            <li>
+              <p className={styles.summaryItemTitle}>{copy.summaryDurationLabel}</p>
+              <p className={styles.summaryItemValue}>{duration?.label}</p>
+            </li>
+          </ul>
+
+          {plan && (
+            <>
+              <p className={styles.summaryFeaturesTitle}>{copy.summaryFeaturesTitle}</p>
+              <ul className={styles.summaryFeatures}>
+                {plan.features.map(feature => (
+                  <li key={feature}>{feature}</li>
+                ))}
+              </ul>
+            </>
+          )}
+
+          <div className={styles.summaryTotal}>
+            <div>
+              <p className={styles.summaryTotalLabel}>{copy.summaryTotalLabel}</p>
+              <p className={styles.summaryPeriod}>{duration?.priceSuffix}</p>
+            </div>
+            <div>
+              <p className={styles.summaryTotalValue}>{formattedTotal}</p>
+              {plan && <p className={styles.summaryPeriod}>{formattedPlanPrice}</p>}
+            </div>
+          </div>
+
+          <button type="button" className={styles.summaryCta}>
+            {copy.summaryCtaLabel}
+          </button>
+          <p className={styles.summaryDisclaimer}>{copy.summaryDisclaimer}</p>
+        </aside>
+      </div>
+    </main>
+  );
+}

--- a/app/order/page.module.css
+++ b/app/order/page.module.css
@@ -1,0 +1,466 @@
+.page {
+  min-height: 100vh;
+  padding: 120px 24px 96px;
+  display: flex;
+  justify-content: center;
+  color: #f4f7ff;
+}
+
+.inner {
+  width: min(1180px, 100%);
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 340px;
+  gap: 32px;
+}
+
+.leftColumn {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.card {
+  background: rgba(15, 24, 45, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 20px;
+  padding: 28px;
+  backdrop-filter: blur(12px);
+}
+
+.heroTitle {
+  font-size: 32px;
+  line-height: 1.2;
+  margin: 0 0 12px;
+}
+
+.heroSubtitle {
+  margin: 0;
+  color: #c6d3f5;
+  max-width: 640px;
+  font-size: 16px;
+  line-height: 1.6;
+}
+
+.sectionHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 20px;
+}
+
+.sectionTitle {
+  font-size: 20px;
+  margin: 0;
+}
+
+.sectionSubtitle {
+  margin: 0;
+  color: #aab7dd;
+  font-size: 14px;
+}
+
+.serviceCards {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+}
+
+.serviceCard {
+  border-radius: 16px;
+  padding: 20px;
+  background: rgba(9, 15, 30, 0.9);
+  border: 1px solid transparent;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  cursor: pointer;
+  transition: border-color 0.2s ease, transform 0.2s ease, background 0.2s ease;
+  text-align: left;
+  color: inherit;
+}
+
+.serviceCard:hover {
+  border-color: rgba(79, 125, 243, 0.5);
+}
+
+.serviceCardActive {
+  border-color: rgba(79, 125, 243, 0.9);
+  background: rgba(79, 125, 243, 0.15);
+  box-shadow: 0 8px 24px rgba(40, 80, 200, 0.25);
+}
+
+.serviceHeadline {
+  font-size: 16px;
+  margin: 0;
+  color: #c6d3f5;
+}
+
+.serviceName {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.serviceBadge {
+  align-self: flex-start;
+  padding: 4px 10px;
+  background: rgba(79, 125, 243, 0.15);
+  color: #9bb7ff;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.servicePrice {
+  margin: 0;
+  font-weight: 600;
+}
+
+.serviceHighlights {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  color: #aab7dd;
+  font-size: 14px;
+}
+
+.planGrid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.planCard {
+  border-radius: 16px;
+  padding: 22px;
+  background: rgba(9, 15, 30, 0.9);
+  border: 1px solid transparent;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  transition: border-color 0.2s ease, background 0.2s ease, transform 0.2s ease;
+  text-align: left;
+  color: inherit;
+}
+
+.planCard:hover {
+  border-color: rgba(126, 158, 255, 0.45);
+}
+
+.planCardActive {
+  border-color: rgba(126, 158, 255, 0.9);
+  background: rgba(126, 158, 255, 0.18);
+  box-shadow: 0 8px 26px rgba(60, 110, 220, 0.25);
+}
+
+.planName {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.planPrice {
+  margin: 0;
+  font-size: 24px;
+  font-weight: 700;
+  display: flex;
+  gap: 6px;
+  align-items: baseline;
+}
+
+.planPriceSuffix {
+  font-size: 14px;
+  color: #aab7dd;
+}
+
+.planSummary {
+  margin: 0;
+  color: #c6d3f5;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.planFeatures {
+  margin: 0;
+  padding-left: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  color: #aab7dd;
+  font-size: 14px;
+}
+
+.selectGroup {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.selectWrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.selectLabel {
+  font-size: 14px;
+  color: #aab7dd;
+}
+
+.select {
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(12, 18, 34, 0.9);
+  color: inherit;
+  padding: 12px 14px;
+  font-size: 14px;
+}
+
+.selectHelp {
+  margin: 0;
+  font-size: 12px;
+  color: #8a99c2;
+}
+
+.durationChips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.durationButton {
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(9, 15, 30, 0.9);
+  color: inherit;
+  padding: 10px 18px;
+  font-size: 14px;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.durationButtonActive {
+  border-color: rgba(110, 147, 255, 0.9);
+  background: rgba(110, 147, 255, 0.2);
+  color: #ffffff;
+  box-shadow: 0 6px 16px rgba(60, 110, 220, 0.25);
+}
+
+.durationDescription {
+  display: block;
+  font-size: 12px;
+  color: #9fb2e9;
+}
+
+.toggleRow {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.toggleSwitch {
+  position: relative;
+  width: 52px;
+  height: 30px;
+  flex: none;
+}
+
+.toggleInput {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.toggleSlider {
+  position: absolute;
+  inset: 0;
+  background: rgba(255, 255, 255, 0.15);
+  border-radius: 999px;
+  transition: background 0.2s ease;
+}
+
+.toggleSlider::before {
+  content: "";
+  position: absolute;
+  width: 24px;
+  height: 24px;
+  left: 3px;
+  top: 3px;
+  border-radius: 50%;
+  background: #101a33;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.toggleInput:checked + .toggleSlider {
+  background: linear-gradient(135deg, #4f7df3 0%, #8f9bff 100%);
+}
+
+.toggleInput:checked + .toggleSlider::before {
+  transform: translateX(22px);
+  background: #ffffff;
+}
+
+.toggleDescription {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.toggleTitle {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.toggleText {
+  margin: 0;
+  color: #aab7dd;
+  font-size: 14px;
+}
+
+.summaryCard {
+  position: sticky;
+  top: 120px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.summaryTitle {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 600;
+}
+
+.summaryList {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.summaryItemTitle {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #8a99c2;
+  margin-bottom: 4px;
+}
+
+.summaryItemValue {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.summaryFeatures {
+  margin: 0;
+  padding-left: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  color: #aab7dd;
+  font-size: 14px;
+}
+
+.summaryFeaturesTitle {
+  margin: 16px 0 8px;
+  font-size: 14px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #8a99c2;
+}
+
+.summaryTotal {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.summaryTotalLabel {
+  font-size: 14px;
+  color: #8a99c2;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.summaryTotalValue {
+  font-size: 28px;
+  font-weight: 700;
+}
+
+.summaryPeriod {
+  font-size: 14px;
+  color: #aab7dd;
+}
+
+.summaryCta {
+  margin-top: 8px;
+  width: 100%;
+  padding: 14px 18px;
+  border-radius: 12px;
+  border: none;
+  background: linear-gradient(135deg, #4f7df3 0%, #8b9bff 100%);
+  color: #ffffff;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.summaryCta:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 26px rgba(56, 102, 225, 0.35);
+}
+
+.summaryDisclaimer {
+  margin: 0;
+  color: #7f8eb8;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.autoRenewState {
+  margin: 0;
+  font-size: 13px;
+  color: #9fb2e9;
+}
+
+@media (max-width: 1100px) {
+  .inner {
+    grid-template-columns: 1fr;
+  }
+
+  .summaryCard {
+    position: static;
+  }
+}
+
+@media (max-width: 720px) {
+  .page {
+    padding: 96px 18px 72px;
+  }
+
+  .card {
+    padding: 22px;
+  }
+
+  .heroTitle {
+    font-size: 28px;
+  }
+
+  .planGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .serviceCards {
+    grid-template-columns: 1fr;
+  }
+}

--- a/app/order/page.tsx
+++ b/app/order/page.tsx
@@ -1,3 +1,5 @@
+import { Suspense } from "react";
+
 import OrderConfigurator from "./OrderConfigurator";
 
 export const metadata = {
@@ -7,5 +9,9 @@ export const metadata = {
 };
 
 export default function Page() {
-  return <OrderConfigurator />;
+  return (
+    <Suspense fallback={null}>
+      <OrderConfigurator />
+    </Suspense>
+  );
 }

--- a/app/order/page.tsx
+++ b/app/order/page.tsx
@@ -1,0 +1,11 @@
+import OrderConfigurator from "./OrderConfigurator";
+
+export const metadata = {
+  title: "SoksLine — Configure your proxy order",
+  description:
+    "Choose a SoksLine proxy service, plan, geo targeting, and billing preferences before completing your purchase.",
+};
+
+export default function Page() {
+  return <OrderConfigurator />;
+}

--- a/components/PricingTemplate.tsx
+++ b/components/PricingTemplate.tsx
@@ -40,6 +40,14 @@ export default function PricingTemplate({ data }: PricingTemplateProps) {
     [copy.categories, activeCategoryId]
   );
 
+  const getLinkProps = (href: string) => {
+    if (/^https?:\/\//i.test(href)) {
+      return { target: "_blank", rel: "noopener" as const };
+    }
+
+    return {};
+  };
+
   return (
     <main className={styles.page}>
       <section className={styles.hero}>
@@ -90,7 +98,7 @@ export default function PricingTemplate({ data }: PricingTemplateProps) {
                     <li key={feature}>{feature}</li>
                   ))}
                 </ul>
-                <Link href={tier.ctaHref} className={styles.planCta} target="_blank" rel="noopener">
+                <Link href={tier.ctaHref} className={styles.planCta} {...getLinkProps(tier.ctaHref)}>
                   {tier.ctaLabel ?? CTA_FALLBACK[locale]}
                 </Link>
               </article>

--- a/components/ProductTemplate.tsx
+++ b/components/ProductTemplate.tsx
@@ -6,6 +6,14 @@ import type { LocalizedProductPage } from "../lib/productPages";
 import { useLocale } from "./LocaleContext";
 import styles from "./ProductTemplate.module.css";
 
+function getLinkProps(href: string) {
+  if (/^https?:\/\//i.test(href)) {
+    return { target: "_blank", rel: "noopener" as const };
+  }
+
+  return {};
+}
+
 type ProductTemplateProps = {
   data: LocalizedProductPage;
   cardsVariant?: "default" | "compact";
@@ -42,7 +50,7 @@ export default function ProductTemplate({ data, cardsVariant = "default" }: Prod
           <p className={styles.heroDescription}>{copy.hero.description}</p>
 
           <div className={styles.heroActions}>
-            <Link href={copy.hero.cta.href} className={styles.primaryCta} target="_blank" rel="noopener">
+            <Link href={copy.hero.cta.href} className={styles.primaryCta} {...getLinkProps(copy.hero.cta.href)}>
               {copy.hero.cta.label}
             </Link>
           </div>
@@ -126,7 +134,7 @@ export default function ProductTemplate({ data, cardsVariant = "default" }: Prod
                   })}
                 </ul>
 
-                <Link href={plan.ctaHref} className={styles.cardCta} target="_blank" rel="noopener">
+                <Link href={plan.ctaHref} className={styles.cardCta} {...getLinkProps(plan.ctaHref)}>
                   {plan.ctaLabel}
                 </Link>
               </article>

--- a/lib/order.ts
+++ b/lib/order.ts
@@ -1,0 +1,523 @@
+import type { Locale } from "../components/LocaleContext";
+
+export type OrderOption = {
+  id: string;
+  label: string;
+  description?: string;
+};
+
+export type OrderDurationOption = OrderOption & {
+  multiplier: number;
+  priceSuffix: string;
+};
+
+export type OrderPlan = {
+  id: string;
+  name: string;
+  priceAmount: number;
+  priceSuffix: string;
+  summary: string;
+  features: string[];
+};
+
+export type OrderService = {
+  id: string;
+  name: string;
+  headline: string;
+  priceHint: string;
+  badge?: string;
+  highlights: string[];
+  currency: string;
+  defaultPlanId?: string;
+  plans: OrderPlan[];
+  durations: OrderDurationOption[];
+  locations: OrderOption[];
+  ispOptions: OrderOption[];
+};
+
+export type OrderPageData = {
+  title: string;
+  subtitle: string;
+  serviceSectionTitle: string;
+  serviceSectionSubtitle: string;
+  planSectionTitle: string;
+  planSectionSubtitle: string;
+  locationSectionTitle: string;
+  locationSectionSubtitle: string;
+  ispSectionTitle: string;
+  ispSectionSubtitle: string;
+  durationSectionTitle: string;
+  durationSectionSubtitle: string;
+  autoRenewLabel: string;
+  autoRenewDescription: string;
+  summaryTitle: string;
+  summaryServiceLabel: string;
+  summaryPlanLabel: string;
+  summaryLocationLabel: string;
+  summaryIspLabel: string;
+  summaryDurationLabel: string;
+  summaryTotalLabel: string;
+  summaryAutoRenewOn: string;
+  summaryAutoRenewOff: string;
+  summaryFeaturesTitle: string;
+  summaryCtaLabel: string;
+  summaryDisclaimer: string;
+  services: OrderService[];
+};
+
+export type LocalizedOrderPage = Record<Locale, OrderPageData>;
+
+export const ORDER_PAGE: LocalizedOrderPage = {
+  ru: {
+    title: "Настройка заказа",
+    subtitle: "Соберите конфигурацию под свою задачу и получите готовые прокси после оплаты.",
+    serviceSectionTitle: "Выберите услугу",
+    serviceSectionSubtitle: "Поддерживаем как статические, так и ротационные residential-пулы.",
+    planSectionTitle: "План",
+    planSectionSubtitle: "Определите уровень доступа и объём ресурсов.",
+    locationSectionTitle: "Местоположение прокси",
+    locationSectionSubtitle: "Задайте страну выдачи и провайдера для подключения.",
+    ispSectionTitle: "ISP",
+    ispSectionSubtitle: "Укажите предпочитаемого интернет-провайдера.",
+    durationSectionTitle: "Выбранный период",
+    durationSectionSubtitle: "Настройте срок действия доступа и биллинг.",
+    autoRenewLabel: "Автопродление",
+    autoRenewDescription: "Продлевать подписку автоматически перед окончанием периода.",
+    summaryTitle: "Сводка заказа",
+    summaryServiceLabel: "Услуга",
+    summaryPlanLabel: "План",
+    summaryLocationLabel: "Локация",
+    summaryIspLabel: "ISP",
+    summaryDurationLabel: "Период",
+    summaryTotalLabel: "Итого",
+    summaryAutoRenewOn: "Автопродление активно",
+    summaryAutoRenewOff: "Без автопродления",
+    summaryFeaturesTitle: "Включено в пакет",
+    summaryCtaLabel: "Далее",
+    summaryDisclaimer: "SSL безопасная оплата. 256-битное шифрование защищает ваши данные.",
+    services: [
+      {
+        id: "static-isp",
+        name: "Static residential (ISP)",
+        headline: "Реальные ASN провайдеров и высокая скорость", 
+        priceHint: "от $1.95 / месяц",
+        badge: "Популярно",
+        highlights: [
+          "Статические IPv4",
+          "Безлимитный трафик",
+          "Выбор городов и ASN",
+        ],
+        currency: "USD",
+        defaultPlanId: "dedicated",
+        plans: [
+          {
+            id: "basic",
+            name: "Basic",
+            priceAmount: 1.95,
+            priceSuffix: "/месяц",
+            summary: "Подходит для небольших команд и тестовых запусков.",
+            features: [
+              "До 3 пользователей",
+              "Sticky-сессии",
+              "HTTP/S и SOCKS5",
+            ],
+          },
+          {
+            id: "dedicated",
+            name: "Dedicated",
+            priceAmount: 2.12,
+            priceSuffix: "/месяц",
+            summary: "Выделенные IP с гибкой ротацией и SLA.",
+            features: [
+              "Неограниченные сессии",
+              "Приоритетная поддержка",
+              "API-доступ",
+            ],
+          },
+          {
+            id: "premium",
+            name: "Premium",
+            priceAmount: 5.47,
+            priceSuffix: "/месяц",
+            summary: "Enterprise-пулы с кастомными подсетями и аналитикой.",
+            features: [
+              "Чистые диапазоны",
+              "Кастомные подсети",
+              "Отдельный менеджер",
+            ],
+          },
+        ],
+        durations: [
+          {
+            id: "weekly",
+            label: "7 дней",
+            description: "Промо-доступ",
+            multiplier: 0.25,
+            priceSuffix: "за 7 дней",
+          },
+          {
+            id: "monthly",
+            label: "1 месяц",
+            description: "Самый популярный",
+            multiplier: 1,
+            priceSuffix: "в месяц",
+          },
+          {
+            id: "yearly",
+            label: "12 месяцев",
+            description: "Экономия 15%",
+            multiplier: 12,
+            priceSuffix: "в год",
+          },
+        ],
+        locations: [
+          { id: "us", label: "США" },
+          { id: "uk", label: "Великобритания" },
+          { id: "de", label: "Германия" },
+          { id: "fr", label: "Франция" },
+        ],
+        ispOptions: [
+          { id: "comcast", label: "Comcast" },
+          { id: "att", label: "AT&T" },
+          { id: "verizon", label: "Verizon" },
+          { id: "spectrum", label: "Spectrum" },
+        ],
+      },
+      {
+        id: "static-residential-ipv6",
+        name: "Static residential IPv6",
+        headline: "Пул IPv6 с мгновенной выдачей",
+        priceHint: "$29.67 / месяц",
+        highlights: [
+          "Выделенные IPv6",
+          "API и дашборд",
+          "Ротация по расписанию",
+        ],
+        currency: "USD",
+        defaultPlanId: "dedicated-ipv6",
+        plans: [
+          {
+            id: "dedicated-ipv6",
+            name: "Dedicated IPv6",
+            priceAmount: 29.67,
+            priceSuffix: "/месяц",
+            summary: "IPv6-линии без шаринга и с управлением через панель.",
+            features: [
+              "Неограниченный трафик",
+              "Кастомные подсети",
+              "SLA 99.9%",
+            ],
+          },
+        ],
+        durations: [
+          {
+            id: "monthly",
+            label: "1 месяц",
+            description: "Мгновенный запуск",
+            multiplier: 1,
+            priceSuffix: "в месяц",
+          },
+          {
+            id: "quarterly",
+            label: "3 месяца",
+            description: "-10%",
+            multiplier: 3,
+            priceSuffix: "за 3 месяца",
+          },
+          {
+            id: "yearly",
+            label: "12 месяцев",
+            description: "Экономия 20%",
+            multiplier: 12,
+            priceSuffix: "в год",
+          },
+        ],
+        locations: [{ id: "us", label: "США" }],
+        ispOptions: [{ id: "dedicated", label: "Выделенные узлы" }],
+      },
+      {
+        id: "rotating-residential",
+        name: "Rotating residential",
+        headline: "85M+ IP и гибкая ротация",
+        priceHint: "$24.95 / GB",
+        highlights: [
+          "Ротация до 30 минут",
+          "Выбор страны и города",
+          "HTTP/S и SOCKS5",
+        ],
+        currency: "USD",
+        defaultPlanId: "bandwidth",
+        plans: [
+          {
+            id: "bandwidth",
+            name: "Bandwidth Pool",
+            priceAmount: 24.95,
+            priceSuffix: "/GB",
+            summary: "Оплата за использованный трафик без скрытых сборов.",
+            features: [
+              "Гибкая ротация",
+              "Неограниченные потоки",
+              "API-интеграция",
+            ],
+          },
+        ],
+        durations: [
+          {
+            id: "3gb",
+            label: "3 GB",
+            description: "Минимальный пакет",
+            multiplier: 3,
+            priceSuffix: "за 3 GB",
+          },
+          {
+            id: "10gb",
+            label: "10 GB",
+            description: "Скидка 10%",
+            multiplier: 10,
+            priceSuffix: "за 10 GB",
+          },
+          {
+            id: "50gb",
+            label: "50 GB",
+            description: "Скидка 15%",
+            multiplier: 50,
+            priceSuffix: "за 50 GB",
+          },
+        ],
+        locations: [
+          { id: "us", label: "США" },
+          { id: "nl", label: "Нидерланды" },
+          { id: "sg", label: "Сингапур" },
+          { id: "br", label: "Бразилия" },
+        ],
+        ispOptions: [{ id: "global", label: "Резиденциальный пул" }],
+      },
+    ],
+  },
+  en: {
+    title: "Configure your order",
+    subtitle: "Build the package that fits your workflow and receive ready-to-use proxies after checkout.",
+    serviceSectionTitle: "Choose a service",
+    serviceSectionSubtitle: "We support both static and rotating residential pools.",
+    planSectionTitle: "Plan",
+    planSectionSubtitle: "Select the access level and resource allocation.",
+    locationSectionTitle: "Proxy location",
+    locationSectionSubtitle: "Decide on the exit country and ISP for your connections.",
+    ispSectionTitle: "ISP",
+    ispSectionSubtitle: "Choose your preferred internet provider.",
+    durationSectionTitle: "Selected period",
+    durationSectionSubtitle: "Define how long access should remain active.",
+    autoRenewLabel: "Auto-renewal",
+    autoRenewDescription: "Renew the subscription automatically before it expires.",
+    summaryTitle: "Order summary",
+    summaryServiceLabel: "Service",
+    summaryPlanLabel: "Plan",
+    summaryLocationLabel: "Location",
+    summaryIspLabel: "ISP",
+    summaryDurationLabel: "Period",
+    summaryTotalLabel: "Total",
+    summaryAutoRenewOn: "Auto-renew enabled",
+    summaryAutoRenewOff: "Auto-renew disabled",
+    summaryFeaturesTitle: "What's included",
+    summaryCtaLabel: "Continue",
+    summaryDisclaimer: "SSL secure payment. Your information is protected with 256-bit encryption.",
+    services: [
+      {
+        id: "static-isp",
+        name: "Static residential (ISP)",
+        headline: "Real ISP ASN with premium speeds",
+        priceHint: "from $1.95 / month",
+        badge: "Popular",
+        highlights: [
+          "Static IPv4 access",
+          "Unlimited bandwidth",
+          "City & ASN targeting",
+        ],
+        currency: "USD",
+        defaultPlanId: "dedicated",
+        plans: [
+          {
+            id: "basic",
+            name: "Basic",
+            priceAmount: 1.95,
+            priceSuffix: "/month",
+            summary: "Perfect for testing and small teams.",
+            features: [
+              "Up to 3 users",
+              "Sticky sessions",
+              "HTTP/S & SOCKS5",
+            ],
+          },
+          {
+            id: "dedicated",
+            name: "Dedicated",
+            priceAmount: 2.12,
+            priceSuffix: "/month",
+            summary: "Dedicated IPs with flexible rotation and SLA.",
+            features: [
+              "Unlimited concurrency",
+              "Priority support",
+              "API access",
+            ],
+          },
+          {
+            id: "premium",
+            name: "Premium",
+            priceAmount: 5.47,
+            priceSuffix: "/month",
+            summary: "Enterprise pools with custom subnets and analytics.",
+            features: [
+              "Clean ranges",
+              "Custom subnets",
+              "Dedicated manager",
+            ],
+          },
+        ],
+        durations: [
+          {
+            id: "weekly",
+            label: "7 days",
+            description: "Promo access",
+            multiplier: 0.25,
+            priceSuffix: "per 7 days",
+          },
+          {
+            id: "monthly",
+            label: "1 month",
+            description: "Most popular",
+            multiplier: 1,
+            priceSuffix: "per month",
+          },
+          {
+            id: "yearly",
+            label: "12 months",
+            description: "Save 15%",
+            multiplier: 12,
+            priceSuffix: "per year",
+          },
+        ],
+        locations: [
+          { id: "us", label: "United States" },
+          { id: "uk", label: "United Kingdom" },
+          { id: "de", label: "Germany" },
+          { id: "fr", label: "France" },
+        ],
+        ispOptions: [
+          { id: "comcast", label: "Comcast" },
+          { id: "att", label: "AT&T" },
+          { id: "verizon", label: "Verizon" },
+          { id: "spectrum", label: "Spectrum" },
+        ],
+      },
+      {
+        id: "static-residential-ipv6",
+        name: "Static residential IPv6",
+        headline: "Instant IPv6 pools",
+        priceHint: "$29.67 / month",
+        highlights: [
+          "Dedicated IPv6",
+          "Dashboard & API",
+          "Scheduled rotation",
+        ],
+        currency: "USD",
+        defaultPlanId: "dedicated-ipv6",
+        plans: [
+          {
+            id: "dedicated-ipv6",
+            name: "Dedicated IPv6",
+            priceAmount: 29.67,
+            priceSuffix: "/month",
+            summary: "Exclusive IPv6 lines managed via dashboard.",
+            features: [
+              "Unlimited traffic",
+              "Custom subnets",
+              "99.9% SLA",
+            ],
+          },
+        ],
+        durations: [
+          {
+            id: "monthly",
+            label: "1 month",
+            description: "Instant provisioning",
+            multiplier: 1,
+            priceSuffix: "per month",
+          },
+          {
+            id: "quarterly",
+            label: "3 months",
+            description: "-10%",
+            multiplier: 3,
+            priceSuffix: "per 3 months",
+          },
+          {
+            id: "yearly",
+            label: "12 months",
+            description: "Save 20%",
+            multiplier: 12,
+            priceSuffix: "per year",
+          },
+        ],
+        locations: [{ id: "us", label: "United States" }],
+        ispOptions: [{ id: "dedicated", label: "Dedicated nodes" }],
+      },
+      {
+        id: "rotating-residential",
+        name: "Rotating residential",
+        headline: "85M+ IPs with flexible rotation",
+        priceHint: "$24.95 / GB",
+        highlights: [
+          "Rotation up to 30 min",
+          "Country & city targeting",
+          "HTTP/S & SOCKS5",
+        ],
+        currency: "USD",
+        defaultPlanId: "bandwidth",
+        plans: [
+          {
+            id: "bandwidth",
+            name: "Bandwidth Pool",
+            priceAmount: 24.95,
+            priceSuffix: "/GB",
+            summary: "Pay exactly for the traffic you consume.",
+            features: [
+              "Flexible rotation",
+              "Unlimited threads",
+              "API integration",
+            ],
+          },
+        ],
+        durations: [
+          {
+            id: "3gb",
+            label: "3 GB",
+            description: "Starter",
+            multiplier: 3,
+            priceSuffix: "per 3 GB",
+          },
+          {
+            id: "10gb",
+            label: "10 GB",
+            description: "10% off",
+            multiplier: 10,
+            priceSuffix: "per 10 GB",
+          },
+          {
+            id: "50gb",
+            label: "50 GB",
+            description: "15% off",
+            multiplier: 50,
+            priceSuffix: "per 50 GB",
+          },
+        ],
+        locations: [
+          { id: "us", label: "United States" },
+          { id: "nl", label: "Netherlands" },
+          { id: "sg", label: "Singapore" },
+          { id: "br", label: "Brazil" },
+        ],
+        ispOptions: [{ id: "global", label: "Residential pool" }],
+      },
+    ],
+  },
+};

--- a/lib/pricing.ts
+++ b/lib/pricing.ts
@@ -32,7 +32,7 @@ export type PricingPageData = {
 
 export type LocalizedPricingPage = Record<Locale, PricingPageData>;
 
-const ORDER_LINK = "https://soksline.com/order";
+const ORDER_LINK = "/order";
 
 export const STATIC_RESIDENTIAL_PRICING: LocalizedPricingPage = {
   ru: {
@@ -60,7 +60,7 @@ export const STATIC_RESIDENTIAL_PRICING: LocalizedPricingPage = {
               "SOCKS5 и HTTP/S",
               "Таргетинг по стране и ISP",
             ],
-            ctaHref: ORDER_LINK,
+            ctaHref: "/order?service=static-isp&plan=basic&duration=weekly",
             ctaLabel: "Оформить",
           },
           {
@@ -77,7 +77,7 @@ export const STATIC_RESIDENTIAL_PRICING: LocalizedPricingPage = {
               "SOCKS5 и HTTP/S",
               "Таргетинг по стране и ISP",
             ],
-            ctaHref: ORDER_LINK,
+            ctaHref: "/order?service=static-isp&plan=basic&duration=monthly",
             ctaLabel: "Оформить",
           },
           {
@@ -93,7 +93,7 @@ export const STATIC_RESIDENTIAL_PRICING: LocalizedPricingPage = {
               "SOCKS5 и HTTP/S",
               "Таргетинг по стране и ISP",
             ],
-            ctaHref: ORDER_LINK,
+            ctaHref: "/order?service=static-isp&plan=basic&duration=yearly",
             ctaLabel: "Оформить",
           },
         ],
@@ -114,7 +114,7 @@ export const STATIC_RESIDENTIAL_PRICING: LocalizedPricingPage = {
               "Двойная авторизация",
               "Приоритетная поддержка",
             ],
-            ctaHref: ORDER_LINK,
+            ctaHref: "/order?service=static-isp&plan=premium&duration=monthly",
             ctaLabel: "Оформить",
           },
           {
@@ -130,7 +130,7 @@ export const STATIC_RESIDENTIAL_PRICING: LocalizedPricingPage = {
               "Двойная авторизация",
               "Приоритетная поддержка",
             ],
-            ctaHref: ORDER_LINK,
+            ctaHref: "/order?service=static-isp&plan=premium&duration=monthly",
             ctaLabel: "Оформить",
           },
           {
@@ -145,7 +145,7 @@ export const STATIC_RESIDENTIAL_PRICING: LocalizedPricingPage = {
               "Двойная авторизация",
               "Приоритетная поддержка",
             ],
-            ctaHref: ORDER_LINK,
+            ctaHref: "/order?service=static-isp&plan=premium&duration=monthly",
             ctaLabel: "Оформить",
           },
         ],
@@ -177,7 +177,7 @@ export const STATIC_RESIDENTIAL_PRICING: LocalizedPricingPage = {
               "SOCKS5 and HTTP/S",
               "Country & ISP-level targeting",
             ],
-            ctaHref: ORDER_LINK,
+            ctaHref: "/order?service=static-isp&plan=basic&duration=weekly",
           },
           {
             id: "month",
@@ -193,7 +193,7 @@ export const STATIC_RESIDENTIAL_PRICING: LocalizedPricingPage = {
               "SOCKS5 and HTTP/S",
               "Country & ISP-level targeting",
             ],
-            ctaHref: ORDER_LINK,
+            ctaHref: "/order?service=static-isp&plan=basic&duration=monthly",
           },
           {
             id: "year",
@@ -208,7 +208,7 @@ export const STATIC_RESIDENTIAL_PRICING: LocalizedPricingPage = {
               "SOCKS5 and HTTP/S",
               "Country & ISP-level targeting",
             ],
-            ctaHref: ORDER_LINK,
+            ctaHref: "/order?service=static-isp&plan=basic&duration=yearly",
           },
         ],
       },
@@ -228,7 +228,7 @@ export const STATIC_RESIDENTIAL_PRICING: LocalizedPricingPage = {
               "Dual Authentication",
               "Priority Support",
             ],
-            ctaHref: ORDER_LINK,
+            ctaHref: "/order?service=static-isp&plan=premium&duration=monthly",
           },
           {
             id: "premium-100",
@@ -243,7 +243,7 @@ export const STATIC_RESIDENTIAL_PRICING: LocalizedPricingPage = {
               "Dual Authentication",
               "Priority Support",
             ],
-            ctaHref: ORDER_LINK,
+            ctaHref: "/order?service=static-isp&plan=premium&duration=monthly",
           },
           {
             id: "premium-250",
@@ -257,7 +257,7 @@ export const STATIC_RESIDENTIAL_PRICING: LocalizedPricingPage = {
               "Dual Authentication",
               "Priority Support",
             ],
-            ctaHref: ORDER_LINK,
+            ctaHref: "/order?service=static-isp&plan=premium&duration=monthly",
           },
         ],
       },
@@ -290,7 +290,7 @@ export const STATIC_IPV6_PRICING: LocalizedPricingPage = {
               "Таргетинг по стране",
               "Безлимитные потоки",
             ],
-            ctaHref: ORDER_LINK,
+            ctaHref: "/order?service=static-residential-ipv6&plan=dedicated-ipv6&duration=monthly",
             ctaLabel: "Оформить",
           },
           {
@@ -305,7 +305,7 @@ export const STATIC_IPV6_PRICING: LocalizedPricingPage = {
               "Таргетинг по стране",
               "Безлимитные потоки",
             ],
-            ctaHref: ORDER_LINK,
+            ctaHref: "/order?service=static-residential-ipv6&plan=dedicated-ipv6&duration=monthly",
             ctaLabel: "Оформить",
           },
           {
@@ -320,7 +320,7 @@ export const STATIC_IPV6_PRICING: LocalizedPricingPage = {
               "Таргетинг по стране",
               "Безлимитные потоки",
             ],
-            ctaHref: ORDER_LINK,
+            ctaHref: "/order?service=static-residential-ipv6&plan=dedicated-ipv6&duration=monthly",
             ctaLabel: "Оформить",
           },
         ],
@@ -341,7 +341,7 @@ export const STATIC_IPV6_PRICING: LocalizedPricingPage = {
               "Геотаргетинг",
               "Безлимитные потоки",
             ],
-            ctaHref: ORDER_LINK,
+            ctaHref: "/order?service=static-residential-ipv6&plan=dedicated-ipv6&duration=quarterly",
             ctaLabel: "Оформить",
           },
           {
@@ -357,7 +357,7 @@ export const STATIC_IPV6_PRICING: LocalizedPricingPage = {
               "Геотаргетинг",
               "Безлимитные потоки",
             ],
-            ctaHref: ORDER_LINK,
+            ctaHref: "/order?service=static-residential-ipv6&plan=dedicated-ipv6&duration=quarterly",
             ctaLabel: "Оформить",
           },
           {
@@ -372,7 +372,7 @@ export const STATIC_IPV6_PRICING: LocalizedPricingPage = {
               "Геотаргетинг",
               "Безлимитные потоки",
             ],
-            ctaHref: ORDER_LINK,
+            ctaHref: "/order?service=static-residential-ipv6&plan=dedicated-ipv6&duration=quarterly",
             ctaLabel: "Оформить",
           },
         ],
@@ -403,7 +403,7 @@ export const STATIC_IPV6_PRICING: LocalizedPricingPage = {
               "Country targeting",
               "Unlimited threads",
             ],
-            ctaHref: ORDER_LINK,
+            ctaHref: "/order?service=static-residential-ipv6&plan=dedicated-ipv6&duration=monthly",
           },
           {
             id: "ipv6-50",
@@ -417,7 +417,7 @@ export const STATIC_IPV6_PRICING: LocalizedPricingPage = {
               "Country targeting",
               "Unlimited threads",
             ],
-            ctaHref: ORDER_LINK,
+            ctaHref: "/order?service=static-residential-ipv6&plan=dedicated-ipv6&duration=monthly",
           },
           {
             id: "ipv6-100",
@@ -431,7 +431,7 @@ export const STATIC_IPV6_PRICING: LocalizedPricingPage = {
               "Country targeting",
               "Unlimited threads",
             ],
-            ctaHref: ORDER_LINK,
+            ctaHref: "/order?service=static-residential-ipv6&plan=dedicated-ipv6&duration=monthly",
           },
         ],
       },
@@ -451,7 +451,7 @@ export const STATIC_IPV6_PRICING: LocalizedPricingPage = {
               "Geo targeting",
               "Unlimited threads",
             ],
-            ctaHref: ORDER_LINK,
+            ctaHref: "/order?service=static-residential-ipv6&plan=dedicated-ipv6&duration=quarterly",
           },
           {
             id: "ipv6-q-50",
@@ -466,7 +466,7 @@ export const STATIC_IPV6_PRICING: LocalizedPricingPage = {
               "Geo targeting",
               "Unlimited threads",
             ],
-            ctaHref: ORDER_LINK,
+            ctaHref: "/order?service=static-residential-ipv6&plan=dedicated-ipv6&duration=quarterly",
           },
           {
             id: "ipv6-q-100",
@@ -480,7 +480,7 @@ export const STATIC_IPV6_PRICING: LocalizedPricingPage = {
               "Geo targeting",
               "Unlimited threads",
             ],
-            ctaHref: ORDER_LINK,
+            ctaHref: "/order?service=static-residential-ipv6&plan=dedicated-ipv6&duration=quarterly",
           },
         ],
       },
@@ -513,7 +513,7 @@ export const ROTATING_RESIDENTIAL_PRICING: LocalizedPricingPage = {
               "Поддержка ISP",
               "Доступ к дашборду",
             ],
-            ctaHref: ORDER_LINK,
+            ctaHref: "/order?service=rotating-residential",
             ctaLabel: "Оформить",
           },
           {
@@ -528,7 +528,7 @@ export const ROTATING_RESIDENTIAL_PRICING: LocalizedPricingPage = {
               "Поддержка ISP",
               "Доступ к дашборду",
             ],
-            ctaHref: ORDER_LINK,
+            ctaHref: "/order?service=rotating-residential",
             ctaLabel: "Оформить",
           },
           {
@@ -543,7 +543,7 @@ export const ROTATING_RESIDENTIAL_PRICING: LocalizedPricingPage = {
               "Поддержка ISP",
               "Приоритетная поддержка",
             ],
-            ctaHref: ORDER_LINK,
+            ctaHref: "/order?service=rotating-residential&plan=bandwidth&duration=3gb",
             ctaLabel: "Оформить",
           },
         ],
@@ -564,7 +564,7 @@ export const ROTATING_RESIDENTIAL_PRICING: LocalizedPricingPage = {
               "Безлимитные потоки",
               "Поддержка 24/7",
             ],
-            ctaHref: ORDER_LINK,
+            ctaHref: "/order?service=rotating-residential&plan=bandwidth&duration=3gb",
             ctaLabel: "Оформить",
           },
           {
@@ -580,7 +580,7 @@ export const ROTATING_RESIDENTIAL_PRICING: LocalizedPricingPage = {
               "Безлимитные потоки",
               "Поддержка 24/7",
             ],
-            ctaHref: ORDER_LINK,
+            ctaHref: "/order?service=rotating-residential&plan=bandwidth&duration=10gb",
             ctaLabel: "Оформить",
           },
         ],
@@ -599,20 +599,20 @@ export const ROTATING_RESIDENTIAL_PRICING: LocalizedPricingPage = {
         id: "bandwidth",
         label: "Bandwidth",
         tiers: [
-          {
-            id: "rotating-3",
-            name: "3 GB",
-            price: "$14.99",
-            period: "per GB",
-            features: [
-              "API rotation",
-              "Sticky up to 30 min",
-              "Country targeting",
-              "ISP filtering",
-              "Dashboard access",
-            ],
-            ctaHref: ORDER_LINK,
-          },
+            {
+              id: "rotating-3",
+              name: "3 GB",
+              price: "$14.99",
+              period: "per GB",
+              features: [
+                "API rotation",
+                "Sticky up to 30 min",
+                "Country targeting",
+                "ISP filtering",
+                "Dashboard access",
+              ],
+              ctaHref: "/order?service=rotating-residential&plan=bandwidth&duration=3gb",
+            },
           {
             id: "rotating-10",
             name: "10 GB",
@@ -625,7 +625,7 @@ export const ROTATING_RESIDENTIAL_PRICING: LocalizedPricingPage = {
               "ISP filtering",
               "Dashboard access",
             ],
-            ctaHref: ORDER_LINK,
+            ctaHref: "/order?service=rotating-residential&plan=bandwidth&duration=10gb",
           },
           {
             id: "rotating-50",
@@ -639,7 +639,7 @@ export const ROTATING_RESIDENTIAL_PRICING: LocalizedPricingPage = {
               "ISP filtering",
               "Priority support",
             ],
-            ctaHref: ORDER_LINK,
+            ctaHref: "/order?service=rotating-residential&plan=bandwidth&duration=50gb",
           },
         ],
       },
@@ -659,7 +659,7 @@ export const ROTATING_RESIDENTIAL_PRICING: LocalizedPricingPage = {
               "Unlimited threads",
               "24/7 support",
             ],
-            ctaHref: ORDER_LINK,
+            ctaHref: "/order?service=rotating-residential",
           },
           {
             id: "rotating-port-20",
@@ -674,7 +674,7 @@ export const ROTATING_RESIDENTIAL_PRICING: LocalizedPricingPage = {
               "Unlimited threads",
               "24/7 support",
             ],
-            ctaHref: ORDER_LINK,
+            ctaHref: "/order?service=rotating-residential",
           },
         ],
       },

--- a/lib/productPages.ts
+++ b/lib/productPages.ts
@@ -54,7 +54,7 @@ export const ISP_PRODUCT_PAGE: LocalizedProductPage = {
         "Стабильность, высокая скорость и безопасность с статическими резидентскими прокси. Настройте доступ за минуты и управляйте сессиями через готовые дашборды.",
       cta: {
         label: "Купить",
-        href: "https://soksline.com/buy/static-isp",
+        href: "/order?service=static-isp",
       },
       metrics: [
         { label: "Скорость", value: "До 1 Гбит/с" },
@@ -84,7 +84,7 @@ export const ISP_PRODUCT_PAGE: LocalizedProductPage = {
             { label: "Без роста одновременных сессий", included: false },
           ],
           ctaLabel: "Продолжить",
-          ctaHref: "https://soksline.com/checkout/static-isp/basic",
+          ctaHref: "/order?service=static-isp&plan=basic",
         },
         {
           id: "dedicated",
@@ -102,7 +102,7 @@ export const ISP_PRODUCT_PAGE: LocalizedProductPage = {
             { label: "Расширение по одновременным сессиям" },
           ],
           ctaLabel: "Продолжить",
-          ctaHref: "https://soksline.com/checkout/static-isp/dedicated",
+          ctaHref: "/order?service=static-isp&plan=dedicated",
         },
         {
           id: "premium",
@@ -119,7 +119,7 @@ export const ISP_PRODUCT_PAGE: LocalizedProductPage = {
             { label: "Расширение по сессиям" },
           ],
           ctaLabel: "Продолжить",
-          ctaHref: "https://soksline.com/checkout/static-isp/premium",
+          ctaHref: "/order?service=static-isp&plan=premium",
         },
       ],
       note: "Нужны объёмы под заказ? Напишите в отдел продаж для кастомных пулов ISP.",
@@ -133,7 +133,7 @@ export const ISP_PRODUCT_PAGE: LocalizedProductPage = {
         "Experience high success rates, stability, security, and speed with static residential proxies. Set up access within minutes and manage sessions with ready-made dashboards.",
       cta: {
         label: "Buy Now",
-        href: "https://soksline.com/buy/static-isp",
+        href: "/order?service=static-isp",
       },
       metrics: [
         { label: "Speed", value: "Up to 1 Gbps" },
@@ -163,7 +163,7 @@ export const ISP_PRODUCT_PAGE: LocalizedProductPage = {
             { label: "No concurrency upgrades", included: false },
           ],
           ctaLabel: "Continue",
-          ctaHref: "https://soksline.com/checkout/static-isp/basic",
+          ctaHref: "/order?service=static-isp&plan=basic",
         },
         {
           id: "dedicated",
@@ -181,7 +181,7 @@ export const ISP_PRODUCT_PAGE: LocalizedProductPage = {
             { label: "Concurrency upgrades" },
           ],
           ctaLabel: "Continue",
-          ctaHref: "https://soksline.com/checkout/static-isp/dedicated",
+          ctaHref: "/order?service=static-isp&plan=dedicated",
         },
         {
           id: "premium",
@@ -198,7 +198,7 @@ export const ISP_PRODUCT_PAGE: LocalizedProductPage = {
             { label: "Concurrency upgrades" },
           ],
           ctaLabel: "Continue",
-          ctaHref: "https://soksline.com/checkout/static-isp/premium",
+          ctaHref: "/order?service=static-isp&plan=premium",
         },
       ],
       note: "Need custom volumes? Contact sales for bespoke ISP proxy pools.",
@@ -215,7 +215,7 @@ export const STATIC_RESIDENTIAL_PAGE: LocalizedProductPage = {
         "Работайте безопасно и без блокировок. IPv6-статик сочетает высокую скорость с широкой географией, а управление доступно через панель или API.",
       cta: {
         label: "Купить",
-        href: "https://soksline.com/buy/static-ipv6",
+        href: "/order?service=static-residential-ipv6",
       },
       metrics: [
         { label: "Уникальные IP", value: "5B+" },
@@ -242,7 +242,7 @@ export const STATIC_RESIDENTIAL_PAGE: LocalizedProductPage = {
             { label: "API и панель" },
           ],
           ctaLabel: "Продолжить",
-          ctaHref: "https://soksline.com/checkout/static-ipv6/dedicated",
+          ctaHref: "/order?service=static-residential-ipv6&plan=dedicated-ipv6",
         },
       ],
       note: "IPv6 лучше всего подходит сервисам, поддерживающим новый протокол.",
@@ -256,7 +256,7 @@ export const STATIC_RESIDENTIAL_PAGE: LocalizedProductPage = {
         "Access the web safely and without restrictions with Static Residential IPv6. Combine fast response times with diverse geo coverage and manage sessions via dashboard or API.",
       cta: {
         label: "Buy Now",
-        href: "https://soksline.com/buy/static-ipv6",
+        href: "/order?service=static-residential-ipv6",
       },
       metrics: [
         { label: "Unique IP Addresses", value: "5B+" },
@@ -282,7 +282,7 @@ export const STATIC_RESIDENTIAL_PAGE: LocalizedProductPage = {
             { label: "API & dashboard" },
           ],
           ctaLabel: "Continue",
-          ctaHref: "https://soksline.com/checkout/static-ipv6/dedicated",
+          ctaHref: "/order?service=static-residential-ipv6&plan=dedicated-ipv6",
         },
       ],
       note: "IPv6 works best with services that support the new protocol stack.",
@@ -299,7 +299,7 @@ export const ROTATING_RESIDENTIAL_PAGE: LocalizedProductPage = {
         "Если важны анонимность, безопасность и высокий процент успешных запросов — ротационная резиденция справится. Настраивайте смену IP по расписанию или через API.",
       cta: {
         label: "Купить",
-        href: "https://soksline.com/buy/rotating",
+        href: "/order?service=rotating-residential",
       },
       metrics: [
         { label: "IP-адреса", value: "85M+" },
@@ -325,7 +325,7 @@ export const ROTATING_RESIDENTIAL_PAGE: LocalizedProductPage = {
             { label: "Неограниченная параллельность" },
           ],
           ctaLabel: "Продолжить",
-          ctaHref: "https://soksline.com/checkout/rotating/bandwidth",
+          ctaHref: "/order?service=rotating-residential&plan=bandwidth",
         },
       ],
       note: "Персональные требования по комплаенсу и KYC доступны по запросу.",
@@ -339,7 +339,7 @@ export const ROTATING_RESIDENTIAL_PAGE: LocalizedProductPage = {
         "When you value anonymity, a high level of online security, and increased success in scraping activities — rotating residential proxies deliver. Rotate on schedule or via API triggers.",
       cta: {
         label: "Buy Now",
-        href: "https://soksline.com/buy/rotating",
+        href: "/order?service=rotating-residential",
       },
       metrics: [
         { label: "IP Addresses", value: "85M+" },
@@ -365,7 +365,7 @@ export const ROTATING_RESIDENTIAL_PAGE: LocalizedProductPage = {
             { label: "Unlimited concurrency" },
           ],
           ctaLabel: "Continue",
-          ctaHref: "https://soksline.com/checkout/rotating/bandwidth",
+          ctaHref: "/order?service=rotating-residential&plan=bandwidth",
         },
       ],
       note: "Custom compliance or KYC requirements available upon request.",


### PR DESCRIPTION
## Summary
- add a localized order configurator page with detailed selectors and a sticky summary card
- link product and pricing CTAs to the new order flow and make link rendering smart about external targets
- provide structured order content and styling assets used by the configurator

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc36723664832aaf068bc28e07155c