### PR TITLE
Center proxy showcase layout on home page

### DIFF
--- a/app/page.module.css
+++ b/app/page.module.css
@@ -112,16 +112,23 @@
 .showcaseInner {
   display: grid;
   gap: clamp(1.8rem, 3vw, 2.6rem);
+  justify-items: center;
+  text-align: center;
 }
 
 .showcaseHeader {
-  justify-self: start;
+  display: grid;
+  gap: 0.5rem;
+  width: min(100%, 42rem);
 }
 
 .showcaseGrid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(240px, 280px));
   gap: clamp(1rem, 2vw, 1.5rem);
+  justify-content: center;
+  justify-items: center;
+  width: 100%;
 }
 
 .showcaseCard {
@@ -174,6 +181,8 @@
   font-weight: 600;
   color: #0f172a;
   letter-spacing: 0.01em;
+  justify-content: center;
+  text-align: center;
 }
 
 .advantagesGrid {
@@ -253,6 +262,14 @@
     gap: 1.1rem;
   }
 
+  .showcaseHeader {
+    width: 100%;
+  }
+
+  .showcaseGrid {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
+
   .showcaseFootnotes {
     gap: 0.75rem 1.25rem;
   }
@@ -260,26 +277,6 @@
   .sectionTitle,
   .paymentsTitle {
     font-size: clamp(1.6rem, 5vw, 2.2rem);
-  }
-}
-
-@media (min-width: 1024px) {
-  .showcaseInner {
-    grid-template-columns: minmax(0, 340px) 1fr;
-    align-items: end;
-  }
-
-  .showcaseHeader {
-    align-self: end;
-    margin-top: clamp(2rem, 6vw, 3.75rem);
-  }
-
-  .showcaseGrid {
-    grid-column: 2;
-  }
-
-  .showcaseFootnotes {
-    grid-column: 1 / -1;
   }
 }
 


### PR DESCRIPTION
## Summary
- center the proxy showcase heading, cards, and metrics for the home page block
- tweak responsive grid breakpoints so the cards stay centered on smaller screens

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dcb3d1b914832aa0cf77393c98847f