### PR TITLE
Fix OrderService type export

### DIFF
--- a/lib/order.ts
+++ b/lib/order.ts
@@ -25,7 +25,7 @@ export type OrderServiceCard = {
   badge?: string;
 };
 
-type OrderSectionSource = {
+export type OrderService = {
   id: string;
   card: OrderServiceCard;
   detailTitle: string;


### PR DESCRIPTION
## Summary
- export the OrderService type from `lib/order.ts` so order page code can reference it

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dce9cacbe0832aa9be54570e6c08ed