### PR TITLE
Move tier ribbons to bottom of order cards

### DIFF
--- a/app/order/page.module.css
+++ b/app/order/page.module.css
@@ -317,7 +317,7 @@
 
 .tierRibbon {
   position: absolute;
-  top: 18px;
+  bottom: 18px;
   right: 18px;
   font-size: 11px;
   letter-spacing: 0.08em;


### PR DESCRIPTION
## Summary
- reposition the order tier ribbon badges to the bottom-right corner of the card to keep prices visible

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcec22cad8832a9df10eb596df594b