### PR TITLE
Move tier ribbons to bottom of order cards

### DIFF
--- a/app/order/OrderPageContent.tsx
+++ b/app/order/OrderPageContent.tsx
@@ -188,7 +188,6 @@ export default function OrderPageContent() {
                       onClick={() => setTierId(tier.id)}
                       aria-pressed={isActive}
                     >
-                      {tier.ribbon && <span className={styles.tierRibbon}>{tier.ribbon}</span>}
                       <header className={styles.tierHeader}>
                         <div>
                           <h3 className={styles.tierName}>{tier.name}</h3>
@@ -206,6 +205,11 @@ export default function OrderPageContent() {
                           <li key={feature}>{feature}</li>
                         ))}
                       </ul>
+                      {tier.ribbon && (
+                        <div className={styles.tierFooter}>
+                          <span className={styles.tierRibbon}>{tier.ribbon}</span>
+                        </div>
+                      )}
                     </button>
                   );
                 })}

--- a/app/order/page.module.css
+++ b/app/order/page.module.css
@@ -315,10 +315,16 @@
   box-shadow: 0 0 0 1px rgba(126, 158, 255, 0.4);
 }
 
+.tierFooter {
+  margin-top: auto;
+  display: flex;
+  justify-content: flex-end;
+  padding-top: 12px;
+}
+
 .tierRibbon {
-  position: absolute;
-  top: 18px;
-  right: 18px;
+  display: inline-flex;
+  align-items: center;
   font-size: 11px;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -327,6 +333,7 @@
   padding: 4px 10px;
   border-radius: 999px;
   font-weight: 700;
+  line-height: 1;
 }
 
 .tierHeader {


### PR DESCRIPTION
## Summary
- reposition the order tier ribbon badges to the bottom-right corner of the card to keep prices visible

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dcec22cad8832a9df10eb596df594b