### PR TITLE
Support configurable placement for pricing ribbons

### DIFF
--- a/app/order/OrderPageContent.tsx
+++ b/app/order/OrderPageContent.tsx
@@ -188,7 +188,6 @@ export default function OrderPageContent() {
                       onClick={() => setTierId(tier.id)}
                       aria-pressed={isActive}
                     >
-                      {tier.ribbon && <span className={styles.tierRibbon}>{tier.ribbon}</span>}
                       <header className={styles.tierHeader}>
                         <div>
                           <h3 className={styles.tierName}>{tier.name}</h3>
@@ -206,6 +205,11 @@ export default function OrderPageContent() {
                           <li key={feature}>{feature}</li>
                         ))}
                       </ul>
+                      {tier.ribbon && (
+                        <div className={styles.tierFooter}>
+                          <span className={styles.tierRibbon}>{tier.ribbon}</span>
+                        </div>
+                      )}
                     </button>
                   );
                 })}

--- a/app/order/page.module.css
+++ b/app/order/page.module.css
@@ -315,10 +315,16 @@
   box-shadow: 0 0 0 1px rgba(126, 158, 255, 0.4);
 }
 
+.tierFooter {
+  margin-top: auto;
+  display: flex;
+  justify-content: flex-end;
+  padding-top: 12px;
+}
+
 .tierRibbon {
-  position: absolute;
-  top: 18px;
-  right: 18px;
+  display: inline-flex;
+  align-items: center;
   font-size: 11px;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -327,6 +333,7 @@
   padding: 4px 10px;
   border-radius: 999px;
   font-weight: 700;
+  line-height: 1;
 }
 
 .tierHeader {

--- a/components/PricingTemplate.module.css
+++ b/components/PricingTemplate.module.css
@@ -88,7 +88,6 @@
 }
 
 .planCard {
-  position: relative;
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(248, 250, 252, 0.9));
   border-radius: 1.5rem;
   padding: 2rem 1.75rem;
@@ -97,6 +96,7 @@
   flex-direction: column;
   gap: 1.25rem;
   border: 1px solid rgba(99, 102, 241, 0.08);
+  position: relative;
 }
 
 .planHeader {
@@ -108,9 +108,8 @@
 }
 
 .planRibbon {
-  position: absolute;
-  top: 1.25rem;
-  right: 1.25rem;
+  display: inline-flex;
+  align-items: center;
   background: #f97316;
   color: #fff;
   font-size: 0.75rem;
@@ -119,6 +118,16 @@
   padding: 0.25rem 0.75rem;
   border-radius: 9999px;
   text-transform: uppercase;
+}
+
+.planRibbonTop {
+  position: absolute;
+  top: 1.5rem;
+  right: 1.75rem;
+}
+
+.planRibbonBottom {
+  align-self: flex-end;
 }
 
 .planName {
@@ -187,7 +196,6 @@
 }
 
 .planCta {
-  margin-top: auto;
   display: inline-flex;
   justify-content: center;
   align-items: center;
@@ -198,6 +206,14 @@
   padding: 0.85rem 1.5rem;
   text-decoration: none;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+  width: 100%;
+}
+
+.planFooter {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
 }
 
 .planCta:hover {
@@ -249,5 +265,10 @@
   .planCard {
     border-radius: 1.25rem;
     padding: 1.75rem 1.5rem;
+  }
+
+  .planRibbonTop {
+    top: 1.25rem;
+    right: 1.5rem;
   }
 }

--- a/components/PricingTemplate.tsx
+++ b/components/PricingTemplate.tsx
@@ -81,28 +81,49 @@ export default function PricingTemplate({ data }: PricingTemplateProps) {
       <section className={styles.plans}>
         <div className={styles.plansInner}>
           <div className={styles.cardsGrid}>
-            {activeCategory?.tiers.map(tier => (
-              <article key={tier.id} className={styles.planCard}>
-                {tier.ribbon && <span className={styles.planRibbon}>{tier.ribbon}</span>}
-                <div className={styles.planHeader}>
-                  <h2 className={styles.planName}>{tier.name}</h2>
-                  {tier.subLabel && <p className={styles.planSubLabel}>{tier.subLabel}</p>}
-                  {tier.headline && <p className={styles.planHeadline}>{tier.headline}</p>}
-                </div>
-                <p className={styles.planPrice}>
-                  <span className={styles.planPriceValue}>{tier.price}</span>
-                  <span className={styles.planPricePeriod}>{tier.period}</span>
-                </p>
-                <ul className={styles.planFeatures}>
-                  {tier.features.map(feature => (
-                    <li key={feature}>{feature}</li>
-                  ))}
-                </ul>
-                <Link href={tier.ctaHref} className={styles.planCta} {...getLinkProps(tier.ctaHref)}>
-                  {tier.ctaLabel ?? CTA_FALLBACK[locale]}
-                </Link>
-              </article>
-            ))}
+            {activeCategory?.tiers.map(tier => {
+              const ribbonPlacement = tier.ribbonPlacement ?? "bottom";
+              const renderRibbon = (placement: "top" | "bottom") =>
+                tier.ribbon ? (
+                  <span
+                    className={`${styles.planRibbon} ${
+                      placement === "top" ? styles.planRibbonTop : styles.planRibbonBottom
+                    }`}
+                  >
+                    {tier.ribbon}
+                  </span>
+                ) : null;
+
+              return (
+                <article key={tier.id} className={styles.planCard}>
+                  {ribbonPlacement === "top" && renderRibbon("top")}
+                  <div className={styles.planHeader}>
+                    <h2 className={styles.planName}>{tier.name}</h2>
+                    {tier.subLabel && <p className={styles.planSubLabel}>{tier.subLabel}</p>}
+                    {tier.headline && <p className={styles.planHeadline}>{tier.headline}</p>}
+                  </div>
+                  <p className={styles.planPrice}>
+                    <span className={styles.planPriceValue}>{tier.price}</span>
+                    <span className={styles.planPricePeriod}>{tier.period}</span>
+                  </p>
+                  <ul className={styles.planFeatures}>
+                    {tier.features.map(feature => (
+                      <li key={feature}>{feature}</li>
+                    ))}
+                  </ul>
+                  <div className={styles.planFooter}>
+                    <Link
+                      href={tier.ctaHref}
+                      className={styles.planCta}
+                      {...getLinkProps(tier.ctaHref)}
+                    >
+                      {tier.ctaLabel ?? CTA_FALLBACK[locale]}
+                    </Link>
+                    {ribbonPlacement === "bottom" && renderRibbon("bottom")}
+                  </div>
+                </article>
+              );
+            })}
           </div>
 
           <footer className={styles.footer}>

--- a/lib/pricing.ts
+++ b/lib/pricing.ts
@@ -12,6 +12,7 @@ export type PricingTier = {
   ctaLabel?: string;
   ctaHref: string;
   ribbon?: string;
+  ribbonPlacement?: "top" | "bottom";
 };
 
 export type PricingCategory = {
@@ -70,6 +71,7 @@ export const STATIC_RESIDENTIAL_PRICING: LocalizedPricingPage = {
             price: "$1.49",
             period: "за прокси",
             ribbon: "ЛУЧШИЙ ПАКЕТ",
+            ribbonPlacement: "top",
             features: [
               "Безлимитный трафик",
               "Неограниченные потоки",
@@ -186,6 +188,7 @@ export const STATIC_RESIDENTIAL_PRICING: LocalizedPricingPage = {
             price: "$1.49",
             period: "per proxy",
             ribbon: "BEST FORMULA",
+            ribbonPlacement: "top",
             features: [
               "Unlimited Bandwidth",
               "Unlimited Threads",


### PR DESCRIPTION
## Summary
- add an optional ribbon placement flag to pricing tiers so featured badges can appear at the top of the card again
- render pricing ribbons either above the card content or inside the footer based on the configured placement
- update pricing card styling so top ribbons are positioned in the card corner while bottom ribbons stay aligned with the CTA

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dcec22cad8832a9df10eb596df594b