### PR TITLE
Fix discount ribbon placement by page

### DIFF
--- a/app/order/page.module.css
+++ b/app/order/page.module.css
@@ -294,7 +294,7 @@
   background: rgba(8, 14, 28, 0.92);
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 20px;
-  padding: 22px;
+  padding: 22px 22px 64px;
   text-align: left;
   color: inherit;
   cursor: pointer;
@@ -316,10 +316,11 @@
 }
 
 .tierFooter {
-  margin-top: auto;
+  position: absolute;
+  right: 22px;
+  bottom: 22px;
   display: flex;
   justify-content: flex-end;
-  padding-top: 12px;
 }
 
 .tierRibbon {

--- a/components/PricingTemplate.tsx
+++ b/components/PricingTemplate.tsx
@@ -82,7 +82,7 @@ export default function PricingTemplate({ data }: PricingTemplateProps) {
         <div className={styles.plansInner}>
           <div className={styles.cardsGrid}>
             {activeCategory?.tiers.map(tier => {
-              const ribbonPlacement = tier.ribbonPlacement ?? "bottom";
+              const ribbonPlacement = tier.ribbonPlacement ?? "top";
               const renderRibbon = (placement: "top" | "bottom") =>
                 tier.ribbon ? (
                   <span


### PR DESCRIPTION
## Summary
- default pricing ribbons to appear at the top of pricing cards outside the order flow
- pin order page discount ribbons to the bottom-right corner of their cards

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd0837ea24832a953fe2d4e63493b4