### PR TITLE
Fix misaligned pricing CTA buttons

### DIFF
--- a/components/PricingTemplate.module.css
+++ b/components/PricingTemplate.module.css
@@ -99,6 +99,13 @@
   position: relative;
 }
 
+.planBody {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  flex: 1;
+}
+
 .planHeader {
   display: flex;
   flex-direction: column;
@@ -175,6 +182,7 @@
   flex-direction: column;
   gap: 0.6rem;
   color: #334155;
+  flex-grow: 1;
 }
 
 .planFeatures li::before {

--- a/components/PricingTemplate.tsx
+++ b/components/PricingTemplate.tsx
@@ -97,20 +97,22 @@ export default function PricingTemplate({ data }: PricingTemplateProps) {
               return (
                 <article key={tier.id} className={styles.planCard}>
                   {ribbonPlacement === "top" && renderRibbon("top")}
-                  <div className={styles.planHeader}>
-                    <h2 className={styles.planName}>{tier.name}</h2>
-                    {tier.subLabel && <p className={styles.planSubLabel}>{tier.subLabel}</p>}
-                    {tier.headline && <p className={styles.planHeadline}>{tier.headline}</p>}
+                  <div className={styles.planBody}>
+                    <div className={styles.planHeader}>
+                      <h2 className={styles.planName}>{tier.name}</h2>
+                      {tier.subLabel && <p className={styles.planSubLabel}>{tier.subLabel}</p>}
+                      {tier.headline && <p className={styles.planHeadline}>{tier.headline}</p>}
+                    </div>
+                    <p className={styles.planPrice}>
+                      <span className={styles.planPriceValue}>{tier.price}</span>
+                      <span className={styles.planPricePeriod}>{tier.period}</span>
+                    </p>
+                    <ul className={styles.planFeatures}>
+                      {tier.features.map(feature => (
+                        <li key={feature}>{feature}</li>
+                      ))}
+                    </ul>
                   </div>
-                  <p className={styles.planPrice}>
-                    <span className={styles.planPriceValue}>{tier.price}</span>
-                    <span className={styles.planPricePeriod}>{tier.period}</span>
-                  </p>
-                  <ul className={styles.planFeatures}>
-                    {tier.features.map(feature => (
-                      <li key={feature}>{feature}</li>
-                    ))}
-                  </ul>
                   <div className={styles.planFooter}>
                     <Link
                       href={tier.ctaHref}


### PR DESCRIPTION
## Summary
- wrap pricing card content so the CTA footer can be consistently anchored
- adjust pricing card styles to stretch the body and feature list for aligned buttons

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd321e08cc832aad70e796e3527d33