### PR TITLE
Adjust pricing CTA button width

### DIFF
--- a/components/PricingTemplate.module.css
+++ b/components/PricingTemplate.module.css
@@ -214,7 +214,8 @@
   padding: 0.85rem 1.5rem;
   text-decoration: none;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
-  width: 100%;
+  width: min(100%, 14rem);
+  align-self: center;
 }
 
 .planFooter {


### PR DESCRIPTION
## Summary
- limit the pricing CTA button width so it no longer touches the card edges
- center the button within the card for a consistent layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd368e55d4832aa911136ca01c3f3f