### PR TITLE
Fix order total calculation for trial, yearly, and premium bundles

### DIFF
--- a/app/order/OrderPageContent.tsx
+++ b/app/order/OrderPageContent.tsx
@@ -78,11 +78,13 @@ export default function OrderPageContent() {
   const currency = activeService?.currency ?? "USD";
   const unitAmount = activeTier?.priceAmount ?? 0;
   const hasUnitPrice = unitAmount > 0;
+  const totalMultiplier = activeTier?.totalMultiplier ?? 1;
+  const totalAmount = unitAmount * totalMultiplier;
   const unitPrice = hasUnitPrice
     ? formatCurrency(unitAmount, locale, currency)
     : activeTier?.price ?? "—";
   const totalPrice = hasUnitPrice
-    ? formatCurrency(unitAmount, locale, currency)
+    ? formatCurrency(totalAmount, locale, currency)
     : activeTier?.price ?? "—";
 
   return (

--- a/lib/order.ts
+++ b/lib/order.ts
@@ -11,6 +11,7 @@ import {
 
 export type OrderTier = PricingTier & {
   priceAmount: number;
+  totalMultiplier: number;
 };
 
 export type OrderCategory = Omit<PricingCategory, "tiers"> & {
@@ -242,6 +243,7 @@ function buildCategories(data: PricingPageData): OrderCategory[] {
     tiers: category.tiers.map(tier => ({
       ...tier,
       priceAmount: parsePriceAmount(tier.price),
+      totalMultiplier: tier.totalMultiplier ?? 1,
     })),
   }));
 }

--- a/lib/pricing.ts
+++ b/lib/pricing.ts
@@ -13,6 +13,7 @@ export type PricingTier = {
   ctaHref: string;
   ribbon?: string;
   ribbonPlacement?: "top" | "bottom";
+  totalMultiplier?: number;
 };
 
 export type PricingCategory = {
@@ -54,6 +55,7 @@ export const STATIC_RESIDENTIAL_PRICING: LocalizedPricingPage = {
             subLabel: "Пробный",
             price: "$1.99",
             period: "за прокси",
+            totalMultiplier: 7 / 30,
             features: [
               "Безлимитный трафик",
               "Неограниченные потоки",
@@ -88,6 +90,7 @@ export const STATIC_RESIDENTIAL_PRICING: LocalizedPricingPage = {
             headline: "Экономия 15%",
             price: "$1.27",
             period: "за прокси",
+            totalMultiplier: 12,
             features: [
               "Безлимитный трафик",
               "Неограниченные потоки",
@@ -109,6 +112,7 @@ export const STATIC_RESIDENTIAL_PRICING: LocalizedPricingPage = {
             name: "25 прокси",
             price: "$2.39",
             period: "за прокси / мес",
+            totalMultiplier: 25,
             features: [
               "Безлимитный трафик",
               "Выделенные подсети",
@@ -125,6 +129,7 @@ export const STATIC_RESIDENTIAL_PRICING: LocalizedPricingPage = {
             ribbon: "-10%",
             price: "$2.19",
             period: "за прокси / мес",
+            totalMultiplier: 100,
             features: [
               "Безлимитный трафик",
               "Выделенные подсети",
@@ -140,6 +145,7 @@ export const STATIC_RESIDENTIAL_PRICING: LocalizedPricingPage = {
             name: "250 прокси",
             price: "$1.99",
             period: "за прокси / мес",
+            totalMultiplier: 250,
             features: [
               "Безлимитный трафик",
               "Выделенные подсети",
@@ -172,6 +178,7 @@ export const STATIC_RESIDENTIAL_PRICING: LocalizedPricingPage = {
             subLabel: "Trial",
             price: "$1.99",
             period: "per proxy",
+            totalMultiplier: 7 / 30,
             features: [
               "Unlimited Bandwidth",
               "Unlimited Threads",
@@ -204,6 +211,7 @@ export const STATIC_RESIDENTIAL_PRICING: LocalizedPricingPage = {
             headline: "Save 15%",
             price: "$1.27",
             period: "per proxy",
+            totalMultiplier: 12,
             features: [
               "Unlimited Bandwidth",
               "Unlimited Threads",
@@ -224,6 +232,7 @@ export const STATIC_RESIDENTIAL_PRICING: LocalizedPricingPage = {
             name: "25 Proxies",
             price: "$2.39",
             period: "per proxy / month",
+            totalMultiplier: 25,
             features: [
               "Unlimited Bandwidth",
               "Dedicated Subnets",
@@ -239,6 +248,7 @@ export const STATIC_RESIDENTIAL_PRICING: LocalizedPricingPage = {
             ribbon: "SAVE 10%",
             price: "$2.19",
             period: "per proxy / month",
+            totalMultiplier: 100,
             features: [
               "Unlimited Bandwidth",
               "Dedicated Subnets",
@@ -253,6 +263,7 @@ export const STATIC_RESIDENTIAL_PRICING: LocalizedPricingPage = {
             name: "250 Proxies",
             price: "$1.99",
             period: "per proxy / month",
+            totalMultiplier: 250,
             features: [
               "Unlimited Bandwidth",
               "Dedicated Subnets",


### PR DESCRIPTION
## Summary
- allow pricing tiers to define a total multiplier representing the billed duration
- ensure order summary totals use the multiplier so trial and yearly plans show correct amounts
- set premium proxy bundle tiers to multiply by proxy count so totals reflect bundle price

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68dd3b02e754832ab8ba024f47bec650