### PR TITLE
Reposition payment section on order page

### DIFF
--- a/app/order/OrderPageContent.tsx
+++ b/app/order/OrderPageContent.tsx
@@ -118,21 +118,6 @@ export default function OrderPageContent() {
             <p className={styles.heroDescription}>{page.copy.heroDescription}</p>
           </section>
 
-          <section className={styles.paymentCard}>
-            <div>
-              <h2 className={styles.paymentTitle}>{page.copy.paymentTitle}</h2>
-              <p className={styles.paymentNote}>{page.paymentNote}</p>
-            </div>
-            <div className={styles.paymentMethods}>
-              <span className={styles.paymentMethodsLabel}>{page.copy.paymentMethodsLabel}</span>
-              <ul className={styles.paymentMethodsList}>
-                {page.paymentMethods.map((method: string) => (
-                  <li key={method}>{method}</li>
-                ))}
-              </ul>
-            </div>
-          </section>
-
           <section className={styles.servicesSection}>
             <header className={styles.servicesHeader}>
               <h2 className={styles.servicesTitle}>{page.copy.servicesSectionTitle}</h2>
@@ -236,6 +221,21 @@ export default function OrderPageContent() {
               </div>
             </section>
           )}
+
+          <section className={styles.paymentCard}>
+            <div>
+              <h2 className={styles.paymentTitle}>{page.copy.paymentTitle}</h2>
+              <p className={styles.paymentNote}>{page.paymentNote}</p>
+            </div>
+            <div className={styles.paymentMethods}>
+              <span className={styles.paymentMethodsLabel}>{page.copy.paymentMethodsLabel}</span>
+              <ul className={styles.paymentMethodsList}>
+                {page.paymentMethods.map((method: string) => (
+                  <li key={method}>{method}</li>
+                ))}
+              </ul>
+            </div>
+          </section>
 
           <section className={styles.contactCard}>
             <div>


### PR DESCRIPTION
## Summary
- move the payment and security section below the service details
- ensure it appears directly above the custom configuration contact card

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd7218d560832aa06f0878b0608ac9