### PR TITLE
Revise order plan layout

### DIFF
--- a/app/order/OrderPageContent.tsx
+++ b/app/order/OrderPageContent.tsx
@@ -225,18 +225,6 @@ export default function OrderPageContent() {
 
           {activeService && (
             <section className={styles.detailSection}>
-              <header className={styles.detailHeader}>
-                <div>
-                  <h2 className={styles.detailTitle}>{activeService.detailTitle}</h2>
-                  <p className={styles.detailSubtitle}>{activeService.detailSubtitle}</p>
-                </div>
-                <Link href={activeService.viewAllHref} className={styles.viewAllLink}>
-                  {page.copy.moreInfoLabel}
-                </Link>
-              </header>
-
-              <p className={styles.detailHighlight}>{activeService.detailHighlight}</p>
-
               {!isRotatingService && activeService.categories.length > 1 && (
                 <div className={styles.categoryTabs}>
                   {activeService.categories.map((category: OrderCategory) => {

--- a/app/order/page.module.css
+++ b/app/order/page.module.css
@@ -223,45 +223,6 @@
   gap: 24px;
 }
 
-.detailHeader {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  gap: 16px;
-}
-
-.detailTitle {
-  margin: 0;
-  font-size: 26px;
-}
-
-.detailSubtitle {
-  margin: 8px 0 0;
-  color: #c6d3f5;
-  max-width: 680px;
-  line-height: 1.6;
-}
-
-.viewAllLink {
-  align-self: center;
-  font-size: 14px;
-  font-weight: 600;
-  color: #9bb7ff;
-  text-decoration: none;
-  transition: color 0.2s ease;
-}
-
-.viewAllLink:hover {
-  color: #c4d5ff;
-}
-
-.detailHighlight {
-  margin: 0;
-  color: #9fb4eb;
-  font-size: 15px;
-  line-height: 1.6;
-}
-
 .categoryTabs {
   display: flex;
   flex-wrap: wrap;

--- a/lib/order.ts
+++ b/lib/order.ts
@@ -79,6 +79,7 @@ type ServiceDefinition = {
   pricing: LocalizedPricingPage;
   currency: string;
   cardCopy: Record<Locale, OrderServiceCard>;
+  orderCategories?: Record<Locale, OrderCategory[]>;
 };
 
 const SERVICE_DEFINITIONS: ServiceDefinition[] = [
@@ -109,6 +110,122 @@ const SERVICE_DEFINITIONS: ServiceDefinition[] = [
         ],
         badge: "Popular",
       },
+    },
+    orderCategories: {
+      ru: [
+        {
+          id: "core-plans",
+          label: "Планы",
+          tiers: [
+            {
+              id: "static-basic",
+              name: "Базовый",
+              price: "$1.95",
+              period: "за прокси / мес",
+              description: "Стартовый набор возможностей для небольших команд.",
+              features: [
+                "До 3 пользователей",
+                "1 ГБ пропускной способности",
+                "Без обновлений скорости",
+                "Без расширения параллельности",
+              ],
+              ctaHref: "/order",
+              priceAmount: 1.95,
+              totalMultiplier: 1,
+            },
+            {
+              id: "static-dedicated",
+              name: "Выделенный",
+              ribbon: "Популярное",
+              price: "$3.95",
+              period: "за прокси / мес",
+              description: "Выделенные ресурсы и комфорт для постоянной работы.",
+              features: [
+                "Выделенные IP для одного пользователя",
+                "Неограниченная пропускная способность",
+                "Обновления скорости включены",
+                "Обновления параллельности включены",
+              ],
+              ctaHref: "/order",
+              priceAmount: 3.95,
+              totalMultiplier: 1,
+            },
+            {
+              id: "static-premium",
+              name: "Премиум",
+              price: "$5.47",
+              period: "за прокси / мес",
+              description: "Чистые IP и максимум возможностей без ограничений.",
+              features: [
+                "Неиспользованные ранее IP",
+                "Неограниченная пропускная способность",
+                "Максимальные обновления скорости",
+                "Максимальная параллельность",
+              ],
+              ctaHref: "/order",
+              priceAmount: 5.47,
+              totalMultiplier: 1,
+            },
+          ],
+        },
+      ],
+      en: [
+        {
+          id: "core-plans",
+          label: "Plans",
+          tiers: [
+            {
+              id: "static-basic",
+              name: "Basic",
+              price: "$1.95",
+              period: "per proxy / mo",
+              description: "Everything you need to get started with a small team.",
+              features: [
+                "Up to 3 users",
+                "1 GB bandwidth cap",
+                "No speed upgrades",
+                "No parallelism upgrades",
+              ],
+              ctaHref: "/order",
+              priceAmount: 1.95,
+              totalMultiplier: 1,
+            },
+            {
+              id: "static-dedicated",
+              name: "Dedicated",
+              ribbon: "Popular",
+              price: "$3.95",
+              period: "per proxy / mo",
+              description: "Dedicated resources tuned for consistent performance.",
+              features: [
+                "Dedicated IP for a single user",
+                "Unlimited bandwidth",
+                "Speed upgrades included",
+                "Parallelism upgrades included",
+              ],
+              ctaHref: "/order",
+              priceAmount: 3.95,
+              totalMultiplier: 1,
+            },
+            {
+              id: "static-premium",
+              name: "Premium",
+              price: "$5.47",
+              period: "per proxy / mo",
+              description: "Fresh IPs and the full power of the SoksLine stack.",
+              features: [
+                "Never-before-used IPs",
+                "Unlimited bandwidth",
+                "Maximum speed upgrades",
+                "Maximum parallelism",
+              ],
+              ctaHref: "/order",
+              priceAmount: 5.47,
+              totalMultiplier: 1,
+            },
+          ],
+        },
+      ],
     },
   },
   {
@@ -251,6 +368,7 @@ function buildCategories(data: PricingPageData): OrderCategory[] {
 function buildService(locale: Locale, definition: ServiceDefinition): OrderService {
   const pricingData = definition.pricing[locale];
   const card = definition.cardCopy[locale];
+  const categories = definition.orderCategories?.[locale] ?? buildCategories(pricingData);
 
   return {
     id: definition.id,
@@ -259,7 +377,7 @@ function buildService(locale: Locale, definition: ServiceDefinition): OrderServi
     detailSubtitle: pricingData.subtitle,
     detailHighlight: pricingData.highlight,
     viewAllHref: `/pricing/${pricingData.slug}`,
-    categories: buildCategories(pricingData),
+    categories,
     currency: definition.currency,
   };
 }


### PR DESCRIPTION
## Summary
- remove the pricing header block from the order detail section so the plan cards are the primary focus
- decouple the static residential order plans from the pricing page and add dedicated tiers with updated copy for both locales
- clean up the order page styles after removing the old header content

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd7986e2dc832a84466f9bb2e38767