### PR TITLE
Allow manual proxy quantity input

### DIFF
--- a/app/order/OrderPageContent.tsx
+++ b/app/order/OrderPageContent.tsx
@@ -382,17 +382,20 @@ export default function OrderPageContent() {
                         <span className={styles.configLabel}>
                           {locale === "ru" ? "Количество прокси (IP)" : "Number of proxies"}
                         </span>
-                        <select
-                          className={styles.configSelect}
+                        <input
+                          type="number"
+                          min={1}
+                          step={1}
+                          inputMode="numeric"
+                          className={styles.configInput}
                           value={selectedQuantity}
                           onChange={(event) => setSelectedQuantity(event.target.value)}
-                        >
-                          {configurationOptions.quantities.map((option) => (
-                            <option key={option.value} value={option.value}>
-                              {option.label}
-                            </option>
-                          ))}
-                        </select>
+                          placeholder={
+                            locale === "ru"
+                              ? "Введите количество"
+                              : "Enter quantity"
+                          }
+                        />
                       </label>
                       <label className={styles.configField}>
                         <span className={styles.configLabel}>

--- a/app/order/page.module.css
+++ b/app/order/page.module.css
@@ -437,6 +437,23 @@
   box-shadow: 0 0 0 3px rgba(126, 158, 255, 0.15);
 }
 
+.configInput {
+  background: rgba(6, 11, 29, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 14px;
+  color: #f4f7ff;
+  padding: 14px 16px;
+  font-size: 15px;
+  line-height: 1.5;
+  width: 100%;
+}
+
+.configInput:focus {
+  outline: none;
+  border-color: rgba(126, 158, 255, 0.8);
+  box-shadow: 0 0 0 3px rgba(126, 158, 255, 0.15);
+}
+
 .configToggle {
   flex-direction: row;
   justify-content: space-between;


### PR DESCRIPTION
## Summary
- replace the proxy quantity dropdown with a numeric input field that accepts custom values
- add styling for the new numeric input to match the existing configuration controls

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ddfc6efa80832aab8dc6c67d47615b