### PR TITLE
Adjust proxy quantity field width

### DIFF
--- a/app/order/page.module.css
+++ b/app/order/page.module.css
@@ -403,8 +403,14 @@
 
 .configGrid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 18px;
+}
+
+@media (max-width: 720px) {
+  .configGrid {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }
 
 .configField {


### PR DESCRIPTION
## Summary
- update the configuration grid to always render two equal columns on wide screens
- add a responsive rule so the grid collapses to a single column on narrow viewports

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de0b06a204832a8011c307cc4f00ae