### PR TITLE
Fix configuration select widths on the order page

### DIFF
--- a/app/order/page.module.css
+++ b/app/order/page.module.css
@@ -435,6 +435,7 @@
   padding: 14px 16px;
   font-size: 15px;
   line-height: 1.5;
+  width: 100%;
 }
 
 .configSelect:focus {


### PR DESCRIPTION
## Summary
- ensure order page configurator select inputs span the full width of their grid columns to align with other fields

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68decbc145c4832ab87093d85bcb0ea8