### PR TITLE
Add border-box sizing to order config fields

### DIFF
--- a/app/order/page.module.css
+++ b/app/order/page.module.css
@@ -436,6 +436,7 @@
   font-size: 15px;
   line-height: 1.5;
   width: 100%;
+  box-sizing: border-box;
 }
 
 .configSelect:focus {
@@ -453,6 +454,7 @@
   font-size: 15px;
   line-height: 1.5;
   width: 100%;
+  box-sizing: border-box;
 }
 
 .configInput:focus {


### PR DESCRIPTION
## Summary
- ensure the order configuration input and select fields use border-box sizing for consistent layouts

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ded5d72d64832a904d5a2f0846d42c