### PR TITLE
UX polish #1: terminology & typos (SOCKS5, AML, brand case)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SoksLine Proxy Store
+# SoksLine SOCKS5 Proxy Store
 
 Next.js (App Router) демо витрина для магазина прокси.
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -32,7 +32,7 @@ type HomeContent = {
 const HOME_CONTENT: Record<Locale, HomeContent> = {
   ru: {
     hero: {
-      eyebrow: "SoksLine Proxy Store",
+      eyebrow: "SoksLine SOCKS5 proxy store",
       title: "Чистые SOCKS-прокси. Прямая линия скорости.",
       subtitle:
         "Покупайте и продавайте прокси в пару кликов. Умные фильтры, актуальная аналитика и прозрачные тарифы помогают командам запускать инфраструктуру без задержек.",
@@ -89,7 +89,7 @@ const HOME_CONTENT: Record<Locale, HomeContent> = {
   },
   en: {
     hero: {
-      eyebrow: "SoksLine Proxy Store",
+      eyebrow: "SoksLine SOCKS5 proxy store",
       title: "Clean SOCKS proxies. Straight-line performance.",
       subtitle:
         "Buy and resell proxies in a couple of clicks. Smart filters, live analytics, and transparent pricing let your team launch infrastructure without delays.",

--- a/components/HeaderNav.tsx
+++ b/components/HeaderNav.tsx
@@ -34,7 +34,7 @@ type NavigationCopy = {
 const NAV_CONTENT: Record<Locale, NavigationCopy> = {
   ru: {
     navLabel: "Главное меню",
-    brandTagline: "Soks5 Proxy store",
+    brandTagline: "SOCKS5 proxy store",
     loginLabel: "Войти",
     navLinks: [
       {
@@ -131,7 +131,7 @@ const NAV_CONTENT: Record<Locale, NavigationCopy> = {
           {
             heading: "Компания",
             items: [
-              { label: "AMP Policy", href: "https://soksline.com/aml-policy" },
+              { label: "AML Policy", href: "https://soksline.com/aml-policy" },
               { label: "Contacts", href: "https://soksline.com/contact" },
             ],
           },
@@ -239,7 +239,7 @@ const NAV_CONTENT: Record<Locale, NavigationCopy> = {
           {
             heading: "Company",
             items: [
-              { label: "AMP Policy", href: "https://soksline.com/aml-policy" },
+              { label: "AML Policy", href: "https://soksline.com/aml-policy" },
               { label: "Contacts", href: "https://soksline.com/contact" },
             ],
           },


### PR DESCRIPTION
## Summary
- align navigation copy with AML policy naming and the SOCKS5 terminology updates
- refresh hero eyebrow text to highlight SoksLine's SOCKS5 positioning in both locales
- update the README heading to reflect the new SOCKS5-centric branding

## Changes
- README.md
- app/page.tsx
- components/HeaderNav.tsx

## Regex
- `\bSoks5\b|\bSocks5\b|\bSOCKS\s*5\b` → `SOCKS5`
- `\bAMP Policy\b` → `AML Policy`

## Screenshots
- ![Hero after](browser:/invocations/smabnvaq/artifacts/artifacts/hero-after.png)
- ![Navigation after](browser:/invocations/smabnvaq/artifacts/artifacts/nav-after.png)
- ![Product card after](browser:/invocations/smabnvaq/artifacts/artifacts/product-card-after.png)

## Testing
- `pnpm install`
- `pnpm lint`
- `CI=1 pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68e02219e3dc832a9fd6823e862fb58a