### PR TITLE
UX polish #5: simple RU/EN i18n (EN default)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,3 +1,4 @@
+import React, { Suspense } from "react";
 import HeaderNav from "@/components/HeaderNav";
 import Footer from "@/components/Footer";
 import { I18nProvider } from "@/lib/i18n";
@@ -8,11 +9,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body style={{ fontFamily: "system-ui, sans-serif", margin: 0, backgroundColor: "#0b1220" }}>
-        <I18nProvider>
-          <HeaderNav />
-          {children}
-          <Footer />
-        </I18nProvider>
+        <Suspense fallback={null}>
+          <I18nProvider>
+            <HeaderNav />
+            {children}
+            <Footer />
+          </I18nProvider>
+        </Suspense>
       </body>
     </html>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,16 +1,18 @@
-import HeaderNav from "../components/HeaderNav";
-import { LocaleProvider } from "../components/LocaleContext";
+import HeaderNav from "@/components/HeaderNav";
+import Footer from "@/components/Footer";
+import { I18nProvider } from "@/lib/i18n";
 
 export const metadata = { title: "SoksLine", description: "Proxy store" };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="ru">
+    <html lang="en">
       <body style={{ fontFamily: "system-ui, sans-serif", margin: 0, backgroundColor: "#0b1220" }}>
-        <LocaleProvider>
+        <I18nProvider>
           <HeaderNav />
           {children}
-        </LocaleProvider>
+          <Footer />
+        </I18nProvider>
       </body>
     </html>
   );

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -44,6 +44,20 @@
   max-width: 52rem;
 }
 
+.heroBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.9rem;
+  border-radius: 9999px;
+  background: rgba(148, 163, 184, 0.2);
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: rgba(226, 232, 240, 0.9);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
 .heroKycNotice {
   display: inline-flex;
   align-items: flex-start;
@@ -52,6 +66,50 @@
   margin: 0 auto;
   font-size: 0.95rem;
   color: rgba(226, 232, 240, 0.82);
+}
+
+.heroActions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
+.heroButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.6rem;
+  border-radius: 9999px;
+  font-weight: 600;
+  font-size: 1rem;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease, color 0.2s ease;
+  border: none;
+}
+
+.heroButtonPrimary {
+  background: linear-gradient(135deg, #2563eb, #7c3aed);
+  color: #ffffff;
+  box-shadow: 0 20px 40px -25px rgba(94, 129, 244, 0.8);
+}
+
+.heroButtonPrimary:hover,
+.heroButtonPrimary:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 25px 45px -22px rgba(94, 129, 244, 0.9);
+}
+
+.heroButtonSecondary {
+  background: rgba(15, 23, 42, 0.15);
+  color: #f8fafc;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.heroButtonSecondary:hover,
+.heroButtonSecondary:focus-visible {
+  transform: translateY(-2px);
+  background: rgba(15, 23, 42, 0.3);
 }
 
 .heroTitle {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import TopProductsTabs from "../components/TopProductsTabs";
-import { useLocale } from "../components/LocaleContext";
-import type { Locale } from "../components/LocaleContext";
-import KycNotice from "../components/KycNotice";
+import TopProductsTabs from "@/components/TopProductsTabs";
+import KycNotice from "@/components/KycNotice";
+import { useI18n } from "@/lib/i18n";
+import type { Locale } from "@/lib/i18n";
 import styles from "./page.module.css";
 
 type Advantage = { title: string; description: string };
@@ -147,8 +147,11 @@ const HOME_CONTENT: Record<Locale, HomeContent> = {
   },
 };
 
+const PRIMARY_CTA = process.env.NEXT_PUBLIC_BOT_URL ?? "https://t.me/your_proxy_bot";
+const SECONDARY_CTA = "https://soksline.com/contact";
+
 export default function Page() {
-  const { locale } = useLocale();
+  const { locale, t } = useI18n();
   const copy = HOME_CONTENT[locale];
 
   return (
@@ -157,9 +160,30 @@ export default function Page() {
         <div className={`${styles.sectionInner} ${styles.heroInner}`}>
           <span className={styles.heroEyebrow}>{copy.hero.eyebrow}</span>
           <div className={styles.heroContent}>
-            <h1 className={styles.heroTitle}>{copy.hero.title}</h1>
-            <p className={styles.heroSubtitle}>{copy.hero.subtitle}</p>
-            <KycNotice className={styles.heroKycNotice} locale={locale} />
+            <span className={styles.heroBadge}>{t('hero.badge', copy.showcase.metrics.join(' • '))}</span>
+            <h1 className={styles.heroTitle}>{t('hero.title', copy.hero.title)}</h1>
+            <p className={styles.heroSubtitle}>{t('hero.subtitle', copy.hero.subtitle)}</p>
+            <div className={styles.heroActions}>
+              <a
+                href={PRIMARY_CTA}
+                className={`${styles.heroButton} ${styles.heroButtonPrimary}`}
+                role="button"
+                target="_blank"
+                rel="noopener"
+              >
+                {t('hero.ctaPrimary')}
+              </a>
+              <a
+                href={SECONDARY_CTA}
+                className={`${styles.heroButton} ${styles.heroButtonSecondary}`}
+                role="button"
+                target="_blank"
+                rel="noopener"
+              >
+                {t('hero.ctaSecondary')}
+              </a>
+            </div>
+            <KycNotice className={styles.heroKycNotice} />
           </div>
         </div>
       </section>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import React from 'react';
+import { useI18n } from '@/lib/i18n';
+
+export default function Footer() {
+  const { t } = useI18n();
+  const year = new Date().getFullYear();
+
+  return (
+    <footer
+      style={{
+        backgroundColor: '#0b1220',
+        color: 'rgba(226, 232, 240, 0.7)',
+        padding: '2rem 0',
+      }}
+    >
+      <div
+        style={{
+          width: 'min(100%, 1120px)',
+          margin: '0 auto',
+          padding: '0 24px',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '0.5rem',
+          fontSize: '0.9rem',
+        }}
+      >
+        <strong style={{ color: '#f8fafc', fontSize: '1rem' }}>{t('brand')}</strong>
+        <span>
+          © {year} {t('brand')}. {t('footer.copyright')}
+        </span>
+      </div>
+    </footer>
+  );
+}

--- a/components/HeaderNav.module.css
+++ b/components/HeaderNav.module.css
@@ -1,57 +1,40 @@
 .wrapper {
   position: sticky;
   top: 0;
-  z-index: 100;
-  background: linear-gradient(90deg, rgba(10, 15, 28, 0.95) 0%, rgba(12, 21, 40, 0.95) 100%);
-  backdrop-filter: blur(18px);
+  z-index: 10;
+  background: rgba(11, 18, 32, 0.95);
+  backdrop-filter: blur(12px);
   border-bottom: 1px solid rgba(148, 163, 184, 0.12);
 }
 
 .inner {
+  width: min(100%, 1120px);
   margin: 0 auto;
-  width: min(100%, 1180px);
-  padding: 0.9rem clamp(1.25rem, 4vw, 2.5rem);
+  padding: 1rem clamp(1.5rem, 5vw, 2.5rem);
   display: flex;
   align-items: center;
-  gap: clamp(1rem, 2vw, 2rem);
-  color: #f8fafc;
+  gap: 1.5rem;
 }
 
 .brand {
   display: inline-flex;
   align-items: center;
   gap: 0.75rem;
-  color: inherit;
+  font-weight: 700;
+  color: #f8fafc;
   text-decoration: none;
-  font-weight: 600;
+  letter-spacing: 0.02em;
 }
 
-.brandIcon {
+.brandMark {
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 0.75rem;
   display: grid;
   place-items: center;
-  width: 2.5rem;
-  height: 2.5rem;
-  border-radius: 999px;
-  background: linear-gradient(135deg, #38bdf8, #2563eb);
+  background: linear-gradient(135deg, #2563eb, #7c3aed);
   font-weight: 700;
-  font-size: 1.1rem;
-}
-
-.brandCopy {
-  display: flex;
-  flex-direction: column;
-  line-height: 1.15;
-  font-size: 0.9rem;
-}
-
-.brandCopy strong {
-  font-size: 1rem;
-}
-
-.brandCopy span {
-  color: rgba(226, 232, 240, 0.7);
-  font-weight: 500;
-  font-size: 0.78rem;
+  color: #ffffff;
 }
 
 .nav {
@@ -60,241 +43,59 @@
 
 .navList {
   display: flex;
-  align-items: center;
-  gap: clamp(0.75rem, 2vw, 1.6rem);
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-
-.navItem,
-.navItemSimple {
-  position: relative;
-}
-
-.navTrigger {
-  background: transparent;
-  border: none;
-  color: inherit;
-  font: inherit;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  cursor: pointer;
-  padding: 0.35rem 0;
-  border-radius: 0.75rem;
-  transition: color 0.2s ease;
-}
-
-.navTriggerActive,
-.navTrigger:hover,
-.navTrigger:focus-visible {
-  color: #38bdf8;
-}
-
-.navCaret {
-  font-size: 0.65rem;
-  opacity: 0.7;
-}
-
-.dropdown {
-  position: absolute;
-  top: calc(100% + 0.6rem);
-  left: 0;
-  background: rgba(15, 23, 42, 0.95);
-  color: #e2e8f0;
-  padding: 1.25rem;
-  border-radius: 1.2rem;
-  box-shadow: 0 28px 60px -40px rgba(2, 6, 23, 0.6);
-  display: none;
-  min-width: 23rem;
-  gap: 1.5rem;
-}
-
-.dropdownOpen {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-}
-
-.dropdownColumn {
-  display: grid;
-  gap: 0.75rem;
-}
-
-.dropdownHeading {
-  margin: 0;
-  font-size: 0.78rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: rgba(148, 163, 184, 0.85);
-}
-
-.dropdownList {
+  flex-wrap: wrap;
+  gap: 1rem 1.5rem;
   list-style: none;
   margin: 0;
   padding: 0;
-  display: grid;
-  gap: 0.65rem;
-}
-
-.dropdownLink {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 1rem;
-  text-decoration: none;
-  color: inherit;
-  padding: 0.55rem 0.75rem;
-  border-radius: 0.9rem;
-  background: transparent;
-  transition: background 0.2s ease, color 0.2s ease;
-}
-
-.dropdownLink:hover,
-.dropdownLink:focus-visible {
-  background: rgba(59, 130, 246, 0.15);
-  color: #bae6fd;
-}
-
-.dropdownLabel {
-  font-size: 0.95rem;
-  font-weight: 600;
-  display: block;
-}
-
-.dropdownDescription {
-  display: block;
-  font-size: 0.78rem;
-  color: rgba(203, 213, 225, 0.78);
-  margin-top: 0.25rem;
-}
-
-.dropdownMeta {
-  font-size: 0.75rem;
-  font-weight: 600;
-  color: #38bdf8;
 }
 
 .navLink {
   color: rgba(226, 232, 240, 0.8);
   text-decoration: none;
-  font-weight: 500;
-  display: inline-flex;
-  align-items: center;
-  padding: 0.35rem 0;
+  font-size: 0.95rem;
   transition: color 0.2s ease;
 }
 
 .navLink:hover,
 .navLink:focus-visible {
-  color: #38bdf8;
+  color: #ffffff;
 }
 
 .actions {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
-.localeSwitch {
+.login {
   display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
-  padding: 0.2rem 0.5rem;
-  border-radius: 999px;
-  background: rgba(15, 23, 42, 0.6);
-  border: 1px solid rgba(148, 163, 184, 0.2);
-}
-
-.localeButton {
-  background: none;
-  border: none;
-  font: inherit;
-  cursor: pointer;
-  padding: 0;
-  font-weight: 600;
-  color: rgba(226, 232, 240, 0.9);
-  transition: color 0.2s ease;
-}
-
-.localeButtonInactive {
-  color: rgba(148, 163, 184, 0.65);
-  font-weight: 500;
-}
-
-.localeButtonActive {
-  color: #f8fafc;
-}
-
-.localeButton:focus-visible {
-  outline: none;
-  color: #38bdf8;
-}
-
-.localeDivider {
-  color: rgba(148, 163, 184, 0.4);
-}
-
-.loginButton {
-  padding: 0.55rem 1.1rem;
-  border-radius: 999px;
+  justify-content: center;
+  padding: 0.45rem 1.1rem;
+  border-radius: 9999px;
+  background: #f8fafc;
+  color: #0b1220;
   text-decoration: none;
   font-weight: 600;
-  color: #0b1220;
-  background: #f8fafc;
-  transition: background 0.2s ease, color 0.2s ease;
+  font-size: 0.95rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.loginButton:hover,
-.loginButton:focus-visible {
-  background: #bae6fd;
-  color: #0f172a;
+.login:hover,
+.login:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 25px -15px rgba(59, 130, 246, 0.8);
 }
 
-@media (max-width: 960px) {
+@media (max-width: 900px) {
   .inner {
-    flex-wrap: wrap;
+    flex-direction: column;
+    align-items: stretch;
     gap: 1rem;
   }
 
-  .nav {
-    order: 3;
-    width: 100%;
-  }
-
-  .navList {
-    flex-wrap: wrap;
-    row-gap: 0.75rem;
-  }
-
-  .dropdown {
-    position: static;
-    margin-top: 0.4rem;
-    background: rgba(15, 23, 42, 0.85);
-    box-shadow: none;
-  }
-
-  .dropdownOpen {
-    display: grid;
-    grid-template-columns: 1fr;
-  }
-}
-
-@media (max-width: 640px) {
-  .inner {
-    justify-content: center;
-  }
-
-  .brandCopy span {
-    display: none;
-  }
-
   .actions {
-    width: 100%;
-    justify-content: center;
-  }
-
-  .navList {
-    justify-content: center;
+    justify-content: space-between;
   }
 }

--- a/components/HeaderNav.tsx
+++ b/components/HeaderNav.tsx
@@ -1,396 +1,51 @@
-"use client";
+'use client';
 
-import Link from "next/link";
-import { useState, useRef, useCallback, FocusEvent, MouseEvent, Fragment } from "react";
-import { Locale, useLocale } from "./LocaleContext";
-import styles from "./HeaderNav.module.css";
+import React from 'react';
+import Link from 'next/link';
+import LanguageSwitcher from '@/components/LanguageSwitcher';
+import { useI18n } from '@/lib/i18n';
+import styles from './HeaderNav.module.css';
 
-type DropdownItem = {
-  label: string;
-  description?: string;
+type NavItem = {
+  key: `nav.${string}`;
   href: string;
-  meta?: string;
+  external?: boolean;
 };
 
-type DropdownSection = {
-  heading?: string;
-  items: DropdownItem[];
-};
-
-type DropdownConfig = {
-  id: string;
-  label: string;
-  sections: DropdownSection[];
-};
-
-type NavigationCopy = {
-  navLabel: string;
-  brandTagline: string;
-  navLinks: DropdownConfig[];
-  auxLinks: { label: string; href: string }[];
-  loginLabel: string;
-};
-
-const NAV_CONTENT: Record<Locale, NavigationCopy> = {
-  ru: {
-    navLabel: "Главное меню",
-    brandTagline: "SOCKS5 proxy store",
-    loginLabel: "Войти",
-    navLinks: [
-      {
-        id: "products",
-        label: "Продукты",
-        sections: [
-          {
-            items: [
-              {
-                label: "Статические ISP прокси (DC/ISP)",
-                description: "Дата-центровые и ISP пуллы для стабильных проектов",
-                href: "/products/isp-proxies",
-              },
-              {
-                label: "Статические резидентские",
-                description: "Реальные жилые IP для долгих сессий и антидетект браузеров",
-                href: "/products/static-residential",
-              },
-              {
-                label: "Ротационные резидентские",
-                description: "Автоматическая смена IP и гибкие лимиты",
-                href: "/products/rotating-residential",
-              },
-            ],
-          },
-        ],
-      },
-      {
-        id: "pricing",
-        label: "Цены",
-        sections: [
-          {
-            heading: "Резидентские прокси",
-            items: [
-              {
-                label: "Статические Residential",
-                description: "Бизнес IP для стабильной работы",
-                meta: "От $1.27 за IP",
-                href: "/pricing/static-residential",
-              },
-              {
-                label: "Статические Residential IPv6",
-                description: "Триллионы ISP IPv6 из США",
-                meta: "От $0.52 за IP",
-                href: "/pricing/static-residential-ipv6",
-              },
-              {
-                label: "Ротационные Residential",
-                description: "Этичный пул резидентских IP",
-                meta: "От $4.99 за IP",
-                href: "/pricing/rotating-residential",
-              },
-            ],
-          },
-        ],
-      },
-      {
-        id: "resources",
-        label: "Ресурсы",
-        sections: [
-          {
-            heading: "Ресурсы",
-            items: [
-              {
-                label: "Могу ли я выбрать геолокацию прокси?",
-                href: "/resources/can-i-select-a-proxy-location",
-              },
-              {
-                label: "Какие варианты таргетинга есть у ваших прокси?",
-                href: "/resources/what-are-the-targeting-options-for-our-proxies",
-              },
-              {
-                label: "Какие решения вы предлагаете?",
-                href: "/resources/what-solutions-do-you-offer",
-              },
-            ],
-          },
-          {
-            items: [
-              {
-                label: "Сколько времени занимает получение заказанных прокси?",
-                href: "/resources/how-long-to-receive-my-ordered-proxies",
-              },
-              {
-                label: "Зачем нужны резидентские прокси?",
-                href: "/resources/why-residential-proxies",
-              },
-              {
-                label: "Что такое ротационный прокси?",
-                href: "/resources/what-is-a-rotating-proxy",
-              },
-            ],
-          },
-          {
-            heading: "Компания",
-            items: [
-              { label: "AML Policy", href: "https://soksline.com/aml-policy" },
-              { label: "Contacts", href: "https://soksline.com/contact" },
-            ],
-          },
-        ],
-      },
-    ],
-    auxLinks: [{ label: "Техподдержка", href: "/help-center" }],
-  },
-  en: {
-    navLabel: "Primary navigation",
-    brandTagline: "Proxy Store & Dedicated rotation",
-    loginLabel: "Log in",
-    navLinks: [
-      {
-        id: "products",
-        label: "Products",
-        sections: [
-          {
-            items: [
-              {
-                label: "Static ISP Proxies (DC/ISP)",
-                description: "Datacenter and ISP pools for uptime-critical use cases",
-                href: "/products/isp-proxies",
-              },
-              {
-                label: "Static Residential",
-                description: "Real residential IPs for long sessions and antidetect browsers",
-                href: "/products/static-residential",
-              },
-              {
-                label: "Rotating Residential",
-                description: "Automated IP rotation with flexible limits",
-                href: "/products/rotating-residential",
-              },
-            ],
-          },
-        ],
-      },
-      {
-        id: "pricing",
-        label: "Pricing",
-        sections: [
-          {
-            heading: "Residential proxies",
-            items: [
-              {
-                label: "Static Residential Proxies",
-                description: "Real business IPs for long-term use",
-                meta: "Starts at $1.27 / proxy",
-                href: "/pricing/static-residential",
-              },
-              {
-                label: "Static Residential IPv6 Proxies",
-                description: "Trillions of ISP IPv6 addresses from the USA",
-                meta: "Starts at $0.52 / proxy",
-                href: "/pricing/static-residential-ipv6",
-              },
-              {
-                label: "Rotating Residential Proxies",
-                description: "Ethically sourced residential proxy pool",
-                meta: "Starts at $4.99 / proxy",
-                href: "/pricing/rotating-residential",
-              },
-            ],
-          },
-        ],
-      },
-      {
-        id: "resources",
-        label: "Resources",
-        sections: [
-          {
-            heading: "Resources",
-            items: [
-              {
-                label: "Can I select a proxy location?",
-                href: "/resources/can-i-select-a-proxy-location",
-              },
-              {
-                label: "What are the targeting options for our proxies?",
-                href: "/resources/what-are-the-targeting-options-for-our-proxies",
-              },
-              {
-                label: "What solutions do you offer?",
-                href: "/resources/what-solutions-do-you-offer",
-              },
-            ],
-          },
-          {
-            items: [
-              {
-                label: "How long does it take to receive my ordered proxies?",
-                href: "/resources/how-long-to-receive-my-ordered-proxies",
-              },
-              {
-                label: "Why Residential Proxies?",
-                href: "/resources/why-residential-proxies",
-              },
-              {
-                label: "What is a rotating proxy?",
-                href: "/resources/what-is-a-rotating-proxy",
-              },
-            ],
-          },
-          {
-            heading: "Company",
-            items: [
-              { label: "AML Policy", href: "https://soksline.com/aml-policy" },
-              { label: "Contacts", href: "https://soksline.com/contact" },
-            ],
-          },
-        ],
-      },
-    ],
-    auxLinks: [{ label: "Help Center", href: "/help-center" }],
-  },
-};
-
-const LOCALE_LABELS: Record<Locale, { short: string; full: string }> = {
-  ru: { short: "Ru", full: "Русский" },
-  en: { short: "En", full: "English" },
-};
-
-const LOCALES: Locale[] = ["ru", "en"];
+const NAV_ITEMS: NavItem[] = [
+  { key: 'nav.pricing', href: '/pricing' },
+  { key: 'nav.contact', href: 'https://soksline.com/contact', external: true },
+  { key: 'nav.aml', href: 'https://soksline.com/aml-policy', external: true },
+  { key: 'nav.privacy', href: 'https://soksline.com/privacy-policy', external: true },
+  { key: 'nav.tos', href: 'https://soksline.com/terms-of-service', external: true },
+  { key: 'nav.aup', href: 'https://soksline.com/acceptable-use-policy', external: true },
+  { key: 'nav.refund', href: 'https://soksline.com/refund-policy', external: true },
+];
 
 export default function HeaderNav() {
-  const [openDropdown, setOpenDropdown] = useState<string | null>(null);
-  const { locale, setLocale } = useLocale();
-  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const navContent = NAV_CONTENT[locale];
-
-  const clearCloseTimer = useCallback(() => {
-    if (closeTimer.current) {
-      clearTimeout(closeTimer.current);
-      closeTimer.current = null;
-    }
-  }, []);
-
-  const handleOpen = useCallback(
-    (id: string | null) => {
-      clearCloseTimer();
-      setOpenDropdown(id);
-    },
-    [clearCloseTimer]
-  );
-
-  const handleScheduleClose = useCallback(() => {
-    clearCloseTimer();
-    closeTimer.current = setTimeout(() => {
-      setOpenDropdown(null);
-      closeTimer.current = null;
-    }, 150);
-  }, [clearCloseTimer]);
-
-  const handleItemClick = useCallback(() => {
-    clearCloseTimer();
-    setOpenDropdown(null);
-  }, [clearCloseTimer]);
-
-  const handleLocaleChange = useCallback(
-    (nextLocale: Locale) => {
-      setLocale(nextLocale);
-      setOpenDropdown(null);
-    },
-    [setLocale]
-  );
-
-  const handleBlur = (event: FocusEvent<HTMLLIElement>) => {
-    const nextFocus = event.relatedTarget as Node | null;
-    if (!nextFocus || !event.currentTarget.contains(nextFocus)) {
-      setOpenDropdown(null);
-    }
-  };
-
-  const handleMouseLeave = (event: MouseEvent<HTMLLIElement>) => {
-    const related = event.relatedTarget as Node | null;
-    if (!related || !event.currentTarget.contains(related)) {
-      handleScheduleClose();
-    }
-  };
+  const { t } = useI18n();
 
   return (
     <header className={styles.wrapper}>
       <div className={styles.inner}>
         <Link href="/" className={styles.brand}>
-          <span className={styles.brandIcon} aria-hidden="true">
+          <span className={styles.brandMark} aria-hidden="true">
             S
           </span>
-          <span className={styles.brandCopy}>
-            <strong>SoksLine</strong>
-            <span>{navContent.brandTagline}</span>
-          </span>
+          <span>{t('brand')}</span>
         </Link>
 
-        <nav className={styles.nav} aria-label={navContent.navLabel}>
+        <nav className={styles.nav} aria-label="Main">
           <ul className={styles.navList}>
-            {navContent.navLinks.map(menu => (
-              <li
-                key={menu.id}
-                className={styles.navItem}
-                onMouseEnter={() => handleOpen(menu.id)}
-                onMouseLeave={handleMouseLeave}
-                onFocus={() => handleOpen(menu.id)}
-                onBlur={handleBlur}
-              >
-                <button
-                  type="button"
-                  className={`${styles.navTrigger} ${openDropdown === menu.id ? styles.navTriggerActive : ""}`}
-                  aria-haspopup="true"
-                  aria-expanded={openDropdown === menu.id}
-                >
-                  {menu.label}
-                  <span aria-hidden="true" className={styles.navCaret}>
-                    ▾
-                  </span>
-                </button>
-
-                <div
-                  className={`${styles.dropdown} ${openDropdown === menu.id ? styles.dropdownOpen : ""}`}
-                  role="menu"
-                  onMouseEnter={() => handleOpen(menu.id)}
-                  onMouseLeave={handleScheduleClose}
-                >
-                  {menu.sections.map(section => (
-                    <div key={section.heading ?? menu.id} className={styles.dropdownColumn}>
-                      {section.heading && <p className={styles.dropdownHeading}>{section.heading}</p>}
-                      <ul className={styles.dropdownList}>
-                        {section.items.map(item => (
-                          <li key={item.label}>
-                            <Link
-                              href={item.href}
-                              className={styles.dropdownLink}
-                              target={item.href.startsWith("http") ? "_blank" : undefined}
-                              rel={item.href.startsWith("http") ? "noopener" : undefined}
-                              onClick={handleItemClick}
-                            >
-                              <span>
-                                <span className={styles.dropdownLabel}>{item.label}</span>
-                                {item.description && <span className={styles.dropdownDescription}>{item.description}</span>}
-                              </span>
-                              {item.meta && <span className={styles.dropdownMeta}>{item.meta}</span>}
-                            </Link>
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
-                  ))}
-                </div>
-              </li>
-            ))}
-            {navContent.auxLinks.map(link => (
-              <li key={link.label} className={styles.navItemSimple}>
+            {NAV_ITEMS.map(item => (
+              <li key={item.key}>
                 <Link
-                  href={link.href}
+                  href={item.href}
                   className={styles.navLink}
-                  target={link.href.startsWith("http") ? "_blank" : undefined}
-                  rel={link.href.startsWith("http") ? "noopener" : undefined}
+                  target={item.external ? '_blank' : undefined}
+                  rel={item.external ? 'noopener' : undefined}
                 >
-                  {link.label}
+                  {t(item.key)}
                 </Link>
               </li>
             ))}
@@ -398,30 +53,14 @@ export default function HeaderNav() {
         </nav>
 
         <div className={styles.actions}>
-          <div className={styles.localeSwitch}>
-            {LOCALES.map((option, index) => (
-              <Fragment key={option}>
-                <button
-                  type="button"
-                  className={`${styles.localeButton} ${
-                    locale === option ? styles.localeButtonActive : styles.localeButtonInactive
-                  }`}
-                  onClick={() => handleLocaleChange(option)}
-                  aria-pressed={locale === option}
-                  aria-label={LOCALE_LABELS[option].full}
-                >
-                  {LOCALE_LABELS[option].short}
-                </button>
-                {index < LOCALES.length - 1 && (
-                  <span className={styles.localeDivider} aria-hidden="true">
-                    |
-                  </span>
-                )}
-              </Fragment>
-            ))}
-          </div>
-          <Link href="https://soksline.com/login" className={styles.loginButton} target="_blank" rel="noopener">
-            {navContent.loginLabel}
+          <LanguageSwitcher />
+          <Link
+            href="https://soksline.com/login"
+            className={styles.login}
+            target="_blank"
+            rel="noopener"
+          >
+            {t('nav.login')}
           </Link>
         </div>
       </div>

--- a/components/KycNotice.tsx
+++ b/components/KycNotice.tsx
@@ -1,5 +1,8 @@
+'use client';
+
 import React from 'react';
 import { getKycPolicy, Locale } from '@/config/policies';
+import { useI18n } from '@/lib/i18n';
 
 type Props = {
   locale?: Locale;         // 'en' | 'ru'; по умолчанию — 'en'
@@ -7,8 +10,9 @@ type Props = {
   inline?: boolean;        // inline-версия внутри карточек
 };
 
-export default function KycNotice({ locale = 'en', className = '', inline = false }: Props) {
-  const text = getKycPolicy(locale);
+export default function KycNotice({ locale, className = '', inline = false }: Props) {
+  const { t } = useI18n();
+  const text = locale ? getKycPolicy(locale) : t('kyc.policy');
   const Wrapper: any = inline ? 'span' : 'div';
   return (
     <Wrapper className={inline ? `text-sm opacity-80 ${className}` : `text-sm opacity-80 mt-2 ${className}`}>

--- a/components/LanguageSwitcher.tsx
+++ b/components/LanguageSwitcher.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import React from 'react';
+import { useI18n } from '@/lib/i18n';
+
+export default function LanguageSwitcher({ className = '' }: { className?: string }) {
+  const { locale, setLocale } = useI18n();
+
+  const baseStyle: React.CSSProperties = {
+    padding: '4px 10px',
+    borderRadius: '9999px',
+    border: '1px solid transparent',
+    fontSize: '0.8rem',
+    fontWeight: 600,
+    backgroundColor: 'rgba(15, 23, 42, 0.08)',
+    color: '#0f172a',
+    cursor: 'pointer',
+  };
+
+  const activeStyle: React.CSSProperties = {
+    backgroundColor: '#0f172a',
+    color: '#ffffff',
+  };
+
+  return (
+    <div className={className} style={{ display: 'inline-flex', alignItems: 'center', gap: '0.35rem' }} aria-label="Language">
+      <button
+        type="button"
+        onClick={() => setLocale('en')}
+        aria-pressed={locale === 'en'}
+        style={{ ...baseStyle, ...(locale === 'en' ? activeStyle : {}) }}
+      >
+        EN
+      </button>
+      <button
+        type="button"
+        onClick={() => setLocale('ru')}
+        aria-pressed={locale === 'ru'}
+        style={{ ...baseStyle, ...(locale === 'ru' ? activeStyle : {}) }}
+      >
+        RU
+      </button>
+    </div>
+  );
+}

--- a/components/LocaleContext.tsx
+++ b/components/LocaleContext.tsx
@@ -1,48 +1,25 @@
-"use client";
+'use client';
 
-import React, {
-  createContext,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-  type Dispatch,
-  type ReactNode,
-  type SetStateAction,
-} from "react";
-
-export type Locale = "ru" | "en";
+import React from 'react';
+import { I18nProvider, useI18n, type Locale } from '@/lib/i18n';
 
 export type LocaleContextValue = {
   locale: Locale;
-  setLocale: Dispatch<SetStateAction<Locale>>;
+  setLocale: ReturnType<typeof useI18n>['setLocale'];
 };
 
-const LocaleContext = createContext<LocaleContextValue | undefined>(undefined);
-
 type LocaleProviderProps = {
-  children: ReactNode;
+  children: React.ReactNode;
   initialLocale?: Locale;
 };
 
-export function LocaleProvider({ children, initialLocale = "ru" }: LocaleProviderProps) {
-  const [locale, setLocale] = useState<Locale>(initialLocale);
-
-  useEffect(() => {
-    document.documentElement.lang = locale;
-  }, [locale]);
-
-  const value = useMemo<LocaleContextValue>(() => ({ locale, setLocale }), [locale]);
-
-  return <LocaleContext.Provider value={value}>{children}</LocaleContext.Provider>;
+export function LocaleProvider({ children, initialLocale }: LocaleProviderProps) {
+  return <I18nProvider initialLocale={initialLocale}>{children}</I18nProvider>;
 }
 
-export function useLocale() {
-  const context = useContext(LocaleContext);
-
-  if (!context) {
-    throw new Error("useLocale must be used within a LocaleProvider");
-  }
-
-  return context;
+export function useLocale(): LocaleContextValue {
+  const { locale, setLocale } = useI18n();
+  return { locale, setLocale };
 }
+
+export type { Locale };

--- a/components/TopProductsTabs.tsx
+++ b/components/TopProductsTabs.tsx
@@ -5,14 +5,19 @@ import Tabs from "@/components/ui/Tabs";
 import StaticIspCard from "@/components/products/StaticIspCard";
 import StaticIpv6Card from "@/components/products/StaticIpv6Card";
 import RotatingResidentialCard from "@/components/products/RotatingResidentialCard";
-
-const TABS = [
-  { id: "static-isp", label: "Static Residential (ISP)" },
-  { id: "static-ipv6", label: "Static Residential (ISP) IPv6" },
-  { id: "rotating", label: "Rotating Residential" },
-];
+import { useI18n } from "@/lib/i18n";
 
 export default function TopProductsTabs() {
+  const { t } = useI18n();
+  const tabs = React.useMemo(
+    () => [
+      { id: "static-isp", label: t("tabs.staticIsp") },
+      { id: "static-ipv6", label: t("tabs.staticIpv6") },
+      { id: "rotating", label: t("tabs.rotating") },
+    ],
+    [t]
+  );
+
   return (
     <section
       aria-labelledby="top-products-heading"
@@ -21,11 +26,11 @@ export default function TopProductsTabs() {
     >
       <div style={{ maxWidth: "1120px", margin: "0 auto", padding: "0 24px" }}>
         <h2 id="top-products-heading" style={{ fontSize: "2rem", fontWeight: 600, margin: "0 0 1rem" }}>
-          Top Products by SoksLine
+          {t("topProducts.title", "Top Products by SoksLine")}
         </h2>
 
         <Tabs
-          tabs={TABS}
+          tabs={tabs}
           idPrefix="top-products"
           renderPanel={(i) => {
             if (i === 0) return <StaticIspCard />;

--- a/config/policies.ts
+++ b/config/policies.ts
@@ -1,4 +1,6 @@
-export type Locale = 'en' | 'ru';
+import type { Locale as I18nLocale } from '@/lib/i18n';
+
+export type Locale = I18nLocale;
 
 export const KYC_POLICY_EN =
   'No KYC for basic plans. KYC upon request for custom configurations and sensitive GEOs.';

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import React from 'react';
+import en from '@/locales/en.json';
+import ru from '@/locales/ru.json';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+
+export type Locale = 'en' | 'ru';
+
+const DICTS: Record<Locale, Record<string, any>> = {
+  en,
+  ru,
+};
+
+const DEFAULT_LOCALE: Locale = 'en';
+
+function isLocale(value: unknown): value is Locale {
+  return value === 'en' || value === 'ru';
+}
+
+function get(obj: any, path: string, fallback?: string) {
+  return path.split('.').reduce((o, k) => (o && k in o ? o[k] : undefined), obj) ?? fallback ?? path;
+}
+
+type Ctx = {
+  locale: Locale;
+  t: (key: string, fb?: string) => string;
+  setLocale: (l: Locale, opts?: { persist?: boolean; updateUrl?: boolean }) => void;
+};
+
+const I18nContext = React.createContext<Ctx | null>(null);
+
+export function I18nProvider({
+  children,
+  initialLocale,
+}: {
+  children: React.ReactNode;
+  initialLocale?: Locale;
+}) {
+  const params = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const paramsString = params?.toString() ?? '';
+
+  const paramLocale = React.useMemo(() => {
+    const search = new URLSearchParams(paramsString);
+    const lang = search.get('lang');
+    return isLocale(lang) ? lang : undefined;
+  }, [paramsString]);
+
+  const storedLocale = React.useMemo(() => {
+    if (typeof window === 'undefined') return undefined;
+    const stored = window.localStorage.getItem('lang');
+    return isLocale(stored) ? stored : undefined;
+  }, []);
+
+  const initial: Locale = initialLocale ?? paramLocale ?? storedLocale ?? DEFAULT_LOCALE;
+  const [locale, _setLocale] = React.useState<Locale>(initial);
+
+  React.useEffect(() => {
+    if (!paramLocale) return;
+    _setLocale(prev => (prev === paramLocale ? prev : paramLocale));
+  }, [paramLocale]);
+
+  const setLocale = React.useCallback(
+    (next: Locale, opts?: { persist?: boolean; updateUrl?: boolean }) => {
+      _setLocale(prev => (prev === next ? prev : next));
+
+      if (opts?.persist !== false && typeof window !== 'undefined') {
+        window.localStorage.setItem('lang', next);
+      }
+
+      if (opts?.updateUrl !== false && typeof window !== 'undefined' && router?.replace && pathname) {
+        const currentParams = new URLSearchParams(paramsString);
+        currentParams.set('lang', next);
+        const query = currentParams.toString();
+        router.replace(query ? `${pathname}?${query}` : pathname);
+      }
+    },
+    [paramsString, pathname, router]
+  );
+
+  React.useEffect(() => {
+    if (typeof document !== 'undefined') {
+      document.documentElement.lang = locale;
+    }
+  }, [locale]);
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem('lang', locale);
+  }, [locale]);
+
+  React.useEffect(() => {
+    if (!router?.replace || !pathname) return;
+    const currentParams = new URLSearchParams(paramsString);
+    const current = currentParams.get('lang');
+    if (current === locale) return;
+    currentParams.set('lang', locale);
+    const query = currentParams.toString();
+    router.replace(query ? `${pathname}?${query}` : pathname);
+  }, [locale, paramsString, pathname, router]);
+
+  const t = React.useCallback((key: string, fb?: string) => get(DICTS[locale], key, fb) as string, [locale]);
+
+  const value = React.useMemo<Ctx>(() => ({ locale, t, setLocale }), [locale, setLocale, t]);
+
+  return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;
+}
+
+export function useI18n() {
+  const ctx = React.useContext(I18nContext);
+  if (!ctx) throw new Error('useI18n must be used within I18nProvider');
+  return ctx;
+}

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,0 +1,34 @@
+{
+  "brand": "SoksLine",
+  "nav": {
+    "pricing": "Pricing",
+    "contact": "Contact",
+    "login": "Log in",
+    "aml": "AML Policy",
+    "privacy": "Privacy",
+    "tos": "Terms",
+    "aup": "AUP",
+    "refund": "Refunds"
+  },
+  "hero": {
+    "title": "SOCKS5 proxy store",
+    "subtitle": "Fast, clean, reliable proxies for your workflows.",
+    "badge": "180+ locations • 99.9% uptime • 24/7 support",
+    "ctaPrimary": "Buy now",
+    "ctaSecondary": "Contact sales"
+  },
+  "tabs": {
+    "staticIsp": "Static Residential (ISP)",
+    "staticIpv6": "Static Residential (ISP) IPv6",
+    "rotating": "Rotating Residential"
+  },
+  "kyc": {
+    "policy": "No KYC for basic plans. KYC upon request for custom configurations and sensitive GEOs."
+  },
+  "footer": {
+    "copyright": "All rights reserved."
+  },
+  "topProducts": {
+    "title": "Top Products by SoksLine"
+  }
+}

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -1,0 +1,34 @@
+{
+  "brand": "SoksLine",
+  "nav": {
+    "pricing": "Тарифы",
+    "contact": "Контакты",
+    "login": "Войти",
+    "aml": "AML Политика",
+    "privacy": "Конфиденциальность",
+    "tos": "Условия",
+    "aup": "AUP",
+    "refund": "Возвраты"
+  },
+  "hero": {
+    "title": "Магазин прокси SOCKS5",
+    "subtitle": "Быстрые, чистые и надёжные прокси для ваших задач.",
+    "badge": "180+ локаций • 99.9% аптайм • 24/7 поддержка",
+    "ctaPrimary": "Купить",
+    "ctaSecondary": "Связаться"
+  },
+  "tabs": {
+    "staticIsp": "Static Residential (ISP)",
+    "staticIpv6": "Static Residential (ISP) IPv6",
+    "rotating": "Rotating Residential"
+  },
+  "kyc": {
+    "policy": "Без KYC для базовых планов. KYC — по запросу для кастомных конфигураций и чувствительных гео."
+  },
+  "footer": {
+    "copyright": "Все права защищены."
+  },
+  "topProducts": {
+    "title": "Топ-продукты SoksLine"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "SoksLine_proj",
+  "name": "soksline-proxy-store",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -10,6 +10,7 @@
         "react-dom": "^19.1.1"
       },
       "devDependencies": {
+        "@playwright/test": "^1.55.1",
         "@testing-library/jest-dom": "^6.8.0",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
@@ -1548,6 +1549,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.1.tgz",
+      "integrity": "sha512-IVAh/nOJaw6W9g+RJVlIQJ6gSiER+ae6mKQ5CX1bERzQgbC1VSeBlwdvczT7pxb0GWiyrxH4TGKbMfDb4Sq/ig==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polka/url": {
@@ -5980,6 +5997,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.1.tgz",
+      "integrity": "sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.1.tgz",
+      "integrity": "sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "devDependencies": {
+    "@playwright/test": "^1.55.1",
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       next:
         specifier: ^15.5.4
-        version: 15.5.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 15.5.4(@playwright/test@1.55.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react:
         specifier: ^19.1.1
         version: 19.2.0
@@ -18,6 +18,9 @@ importers:
         specifier: ^19.1.1
         version: 19.2.0(react@19.2.0)
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.55.1
+        version: 1.55.1
       '@testing-library/jest-dom':
         specifier: ^6.8.0
         version: 6.9.1
@@ -538,6 +541,11 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@playwright/test@1.55.1':
+    resolution: {integrity: sha512-IVAh/nOJaw6W9g+RJVlIQJ6gSiER+ae6mKQ5CX1bERzQgbC1VSeBlwdvczT7pxb0GWiyrxH4TGKbMfDb4Sq/ig==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -1392,6 +1400,11 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1860,6 +1873,16 @@ packages:
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  playwright-core@1.55.1:
+    resolution: {integrity: sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.55.1:
+    resolution: {integrity: sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -2703,6 +2726,10 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
+  '@playwright/test@1.55.1':
+    dependencies:
+      playwright: 1.55.1
+
   '@polka/url@1.0.0-next.29': {}
 
   '@rollup/rollup-android-arm-eabi@4.52.4':
@@ -3470,8 +3497,8 @@ snapshots:
       '@typescript-eslint/parser': 8.45.0(eslint@9.36.0)(typescript@5.9.3)
       eslint: 9.36.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.36.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.36.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.36.0)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.36.0)(typescript@5.9.3))(eslint@9.36.0))(eslint@9.36.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.36.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.36.0)(typescript@5.9.3))(eslint@9.36.0))(eslint@9.36.0))(eslint@9.36.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.36.0)
       eslint-plugin-react: 7.37.5(eslint@9.36.0)
       eslint-plugin-react-hooks: 5.2.0(eslint@9.36.0)
@@ -3490,7 +3517,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.36.0):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.36.0)(typescript@5.9.3))(eslint@9.36.0))(eslint@9.36.0):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -3501,22 +3528,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.36.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.36.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.36.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.36.0)(typescript@5.9.3))(eslint@9.36.0))(eslint@9.36.0))(eslint@9.36.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.45.0(eslint@9.36.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.36.0):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.45.0(eslint@9.36.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.36.0)(typescript@5.9.3))(eslint@9.36.0))(eslint@9.36.0))(eslint@9.36.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.45.0(eslint@9.36.0)(typescript@5.9.3)
       eslint: 9.36.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.36.0)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.36.0)(typescript@5.9.3))(eslint@9.36.0))(eslint@9.36.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.36.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.36.0):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.36.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.36.0)(typescript@5.9.3))(eslint@9.36.0))(eslint@9.36.0))(eslint@9.36.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -3527,7 +3554,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.36.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.45.0(eslint@9.36.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.36.0)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.45.0(eslint@9.36.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.36.0)(typescript@5.9.3))(eslint@9.36.0))(eslint@9.36.0))(eslint@9.36.0)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -3718,6 +3745,9 @@ snapshots:
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -4095,7 +4125,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@15.5.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  next@15.5.4(@playwright/test@1.55.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       '@next/env': 15.5.4
       '@swc/helpers': 0.5.15
@@ -4113,6 +4143,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.5.4
       '@next/swc-win32-arm64-msvc': 15.5.4
       '@next/swc-win32-x64-msvc': 15.5.4
+      '@playwright/test': 1.55.1
       sharp: 0.34.4
     transitivePeerDependencies:
       - '@babel/core'
@@ -4206,6 +4237,14 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.3: {}
+
+  playwright-core@1.55.1: {}
+
+  playwright@1.55.1:
+    dependencies:
+      playwright-core: 1.55.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 

--- a/tests/i18n.spec.ts
+++ b/tests/i18n.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test';
+
+test('i18n switch persists', async ({ page }) => {
+  await page.goto('/');
+
+  await expect(page.getByRole('button', { name: 'Buy now' })).toBeVisible();
+
+  await page.getByRole('button', { name: 'RU' }).click();
+  await expect(page.getByRole('button', { name: 'Купить' })).toBeVisible();
+  await page.reload();
+  await expect(page.getByRole('button', { name: 'Купить' })).toBeVisible();
+  await expect(page).toHaveURL(/lang=ru/);
+
+  await page.getByRole('button', { name: 'EN' }).click();
+  await expect(page.getByRole('button', { name: 'Buy now' })).toBeVisible();
+  await expect(page).toHaveURL(/lang=en/);
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,17 @@
-﻿import "@testing-library/jest-dom";
+import "@testing-library/jest-dom";
+import { beforeEach, vi } from "vitest";
+
+const mockReplace = vi.fn();
+const mockSearchParams = new URLSearchParams();
+const router = { replace: mockReplace };
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => router,
+  usePathname: () => "/",
+  useSearchParams: () => mockSearchParams,
+}));
+
+beforeEach(() => {
+  mockReplace.mockClear();
+  Array.from(mockSearchParams.keys()).forEach(key => mockSearchParams.delete(key));
+});


### PR DESCRIPTION
## Summary
- add a lightweight RU/EN i18n provider with persisted language preference and locale dictionaries
- replace the header, hero, footer, and product tabs copy with translated strings and surface a reusable language switcher
- update KYC messaging, layout wiring, and tests to integrate the new provider plus add a Playwright check for language persistence

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e0d4ee77cc832ab08f9e4a952b9b1c