### PR TITLE
UX polish #7: Hero cleanup + primary/secondary CTAs (EN default)

### DIFF
--- a/app/page.module.css
+++ b/app/page.module.css
@@ -1,7 +1,7 @@
 .page {
   display: flex;
   flex-direction: column;
-  background: #0b1220;
+  background: #ffffff;
   min-height: 100vh;
   padding-top: clamp(4.5rem, 8vw, 5.25rem);
   scroll-padding-top: clamp(4.5rem, 8vw, 5.25rem);
@@ -16,132 +16,6 @@
   margin: 0 auto;
   padding: 0 clamp(1.5rem, 6vw, 5.5rem);
   box-sizing: border-box;
-}
-
-.hero {
-  background: linear-gradient(135deg, #0f172a 0%, #17233d 55%, #111927 100%);
-  color: #f8fafc;
-  text-align: center;
-}
-
-.heroInner {
-  display: grid;
-  gap: clamp(1.5rem, 3vw, 2.5rem);
-  justify-items: center;
-}
-
-.heroEyebrow {
-  font-size: 0.85rem;
-  font-weight: 600;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: rgba(226, 232, 240, 0.75);
-}
-
-.heroContent {
-  display: grid;
-  gap: clamp(1.25rem, 2.5vw, 1.9rem);
-  max-width: 52rem;
-}
-
-.heroBadge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.35rem 0.9rem;
-  border-radius: 9999px;
-  background: rgba(148, 163, 184, 0.2);
-  font-size: 0.85rem;
-  font-weight: 600;
-  color: rgba(226, 232, 240, 0.9);
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-}
-
-.heroKycNotice {
-  display: inline-flex;
-  align-items: flex-start;
-  justify-content: center;
-  gap: 0.35rem;
-  margin: 0 auto;
-  font-size: 0.95rem;
-  color: rgba(226, 232, 240, 0.82);
-}
-
-.heroActions {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 0.75rem;
-}
-
-.heroButton {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.75rem 1.6rem;
-  border-radius: 9999px;
-  font-weight: 600;
-  font-size: 1rem;
-  text-decoration: none;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease, color 0.2s ease;
-  border: none;
-}
-
-.heroButtonPrimary {
-  background: linear-gradient(135deg, #2563eb, #7c3aed);
-  color: #ffffff;
-  box-shadow: 0 20px 40px -25px rgba(94, 129, 244, 0.8);
-}
-
-.heroButtonPrimary:hover,
-.heroButtonPrimary:focus-visible {
-  transform: translateY(-2px);
-  box-shadow: 0 25px 45px -22px rgba(94, 129, 244, 0.9);
-}
-
-.heroButtonSecondary {
-  background: rgba(15, 23, 42, 0.15);
-  color: #f8fafc;
-  border: 1px solid rgba(148, 163, 184, 0.35);
-}
-
-.heroButtonSecondary:hover,
-.heroButtonSecondary:focus-visible {
-  transform: translateY(-2px);
-  background: rgba(15, 23, 42, 0.3);
-}
-
-.heroTitle {
-  font-size: clamp(2.4rem, 6vw, 3.6rem);
-  line-height: 1.1;
-  margin: 0;
-  font-weight: 700;
-}
-
-.heroSubtitle {
-  margin: 0;
-  font-size: clamp(1.1rem, 2vw, 1.3rem);
-  line-height: 1.55;
-  color: rgba(226, 232, 240, 0.78);
-}
-
-.media {
-  background: linear-gradient(135deg, #dbeafe 0%, #ede9fe 60%, #f8fafc 100%);
-  color: #3730a3;
-}
-
-.mediaInner {
-  display: grid;
-  place-items: center;
-  min-height: clamp(14rem, 35vw, 18rem);
-  text-align: center;
-}
-
-.mediaLabel {
-  font-size: clamp(1rem, 2vw, 1.2rem);
-  font-weight: 500;
-  opacity: 0.85;
 }
 
 .sectionHeader {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,7 @@
 "use client";
 
-import Link from "next/link";
-import ExternalLink from "@/components/ExternalLink";
+import Hero from "@/components/Hero";
 import TopProductsTabs from "@/components/TopProductsTabs";
-import KycNotice from "@/components/KycNotice";
 import { useI18n } from "@/lib/i18n";
 import type { Locale } from "@/lib/i18n";
 import styles from "./page.module.css";
@@ -12,8 +10,6 @@ type Advantage = { title: string; description: string };
 type ShowcaseItem = { title: string; price: string; points: string[] };
 
 type HomeContent = {
-  hero: { eyebrow: string; title: string; subtitle: string };
-  mediaLabel: string;
   showcase: {
     title: string;
     description: string;
@@ -34,13 +30,6 @@ type HomeContent = {
 
 const HOME_CONTENT: Record<Locale, HomeContent> = {
   ru: {
-    hero: {
-      eyebrow: "SoksLine SOCKS5 proxy store",
-      title: "Чистые SOCKS-прокси. Прямая линия скорости.",
-      subtitle:
-        "Покупайте и продавайте прокси в пару кликов. Умные фильтры, актуальная аналитика и прозрачные тарифы помогают командам запускать инфраструктуру без задержек.",
-    },
-    mediaLabel: "[Плейсхолдер изображения / видео превью]",
     showcase: {
       title: "Выберите формат прокси",
       description:
@@ -91,13 +80,6 @@ const HOME_CONTENT: Record<Locale, HomeContent> = {
     },
   },
   en: {
-    hero: {
-      eyebrow: "SoksLine SOCKS5 proxy store",
-      title: "Clean SOCKS proxies. Straight-line performance.",
-      subtitle:
-        "Buy and resell proxies in a couple of clicks. Smart filters, live analytics, and transparent pricing let your team launch infrastructure without delays.",
-    },
-    mediaLabel: "[Image or video preview placeholder]",
     showcase: {
       title: "Choose your proxy format",
       description:
@@ -149,49 +131,13 @@ const HOME_CONTENT: Record<Locale, HomeContent> = {
   },
 };
 
-const PRIMARY_CTA = process.env.NEXT_PUBLIC_BOT_URL ?? "https://t.me/your_proxy_bot";
-const SECONDARY_CTA = "/contact";
-
 export default function Page() {
-  const { locale, t } = useI18n();
+  const { locale } = useI18n();
   const copy = HOME_CONTENT[locale];
 
   return (
     <main className={styles.page}>
-      <section className={`${styles.section} ${styles.hero}`} id="hero">
-        <div className={`${styles.sectionInner} ${styles.heroInner}`}>
-          <span className={styles.heroEyebrow}>{copy.hero.eyebrow}</span>
-          <div className={styles.heroContent}>
-            <span className={styles.heroBadge}>{t('hero.badge', copy.showcase.metrics.join(' • '))}</span>
-            <h1 className={styles.heroTitle}>{t('hero.title', copy.hero.title)}</h1>
-            <p className={styles.heroSubtitle}>{t('hero.subtitle', copy.hero.subtitle)}</p>
-            <div className={styles.heroActions}>
-              <ExternalLink
-                href={PRIMARY_CTA}
-                className={`${styles.heroButton} ${styles.heroButtonPrimary}`}
-                ariaLabel={t('hero.ctaPrimary')}
-                role="button"
-              >
-                {t('hero.ctaPrimary')}
-              </ExternalLink>
-              <Link
-                href={SECONDARY_CTA}
-                className={`${styles.heroButton} ${styles.heroButtonSecondary}`}
-                role="button"
-              >
-                {t('hero.ctaSecondary')}
-              </Link>
-            </div>
-            <KycNotice className={styles.heroKycNotice} />
-          </div>
-        </div>
-      </section>
-
-      <section className={`${styles.section} ${styles.media}`} aria-label={copy.mediaLabel} id="media-preview">
-        <div className={`${styles.sectionInner} ${styles.mediaInner}`}>
-          <span className={styles.mediaLabel}>{copy.mediaLabel}</span>
-        </div>
-      </section>
+      <Hero />
 
       <section className={`${styles.section} ${styles.showcase}`} id="proxy-formats">
         <div className={`${styles.sectionInner} ${styles.showcaseInner}`}>

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { useI18n } from '@/lib/i18n';
+
+export default function Hero() {
+  const { t } = useI18n();
+
+  return (
+    <section
+      aria-labelledby="hero-heading"
+      className="mx-auto max-w-6xl px-4 pt-16 pb-14 sm:pt-20 sm:pb-16"
+    >
+      <div className="grid gap-8 lg:grid-cols-2 lg:items-center">
+        {/* Text */}
+        <div>
+          <h1 id="hero-heading" className="text-4xl font-extrabold tracking-tight sm:text-5xl">
+            {t('hero.title')}
+          </h1>
+
+          <p className="mt-4 text-lg leading-7 text-gray-700">
+            {t('hero.subtitle')}
+          </p>
+
+          {/* Badge / trust bar */}
+          <div className="mt-4 text-sm text-gray-600">
+            {t('hero.badge')}
+          </div>
+
+          {/* CTAs */}
+          <div className="mt-8 flex flex-wrap items-center gap-3">
+            <Link
+              href="/pricing"
+              className="inline-flex items-center justify-center rounded-2xl px-5 py-3 text-base font-medium bg-gray-900 text-white hover:bg-black focus:outline-none focus-visible:ring focus-visible:ring-offset-2"
+              aria-label={t('hero.ctaPrimary')}
+            >
+              {t('hero.ctaPrimary')}
+            </Link>
+
+            <Link
+              href="/contact"
+              className="inline-flex items-center justify-center rounded-2xl px-5 py-3 text-base font-medium bg-white text-gray-900 border border-gray-300 hover:bg-gray-50 focus:outline-none focus-visible:ring focus-visible:ring-offset-2"
+              aria-label={t('hero.ctaSecondary')}
+            >
+              {t('hero.ctaSecondary')}
+            </Link>
+          </div>
+        </div>
+
+        {/* Media placeholder (image only) */}
+        <div className="relative aspect-[16/10] w-full overflow-hidden rounded-2xl border border-gray-200 bg-gray-50">
+          <Image
+            src="/hero-placeholder.svg"
+            alt="Dashboard preview of SoksLine proxy store"
+            fill
+            className="object-cover"
+            priority
+          />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/public/hero-placeholder.svg
+++ b/public/hero-placeholder.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 1000" role="img" aria-label="Stylized dashboard placeholder">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#eef2ff" />
+      <stop offset="50%" stop-color="#e0f2fe" />
+      <stop offset="100%" stop-color="#f8fafc" />
+    </linearGradient>
+    <linearGradient id="card" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.95" />
+      <stop offset="100%" stop-color="#f1f5f9" stop-opacity="0.9" />
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="1000" fill="url(#bg)" rx="60" />
+  <g transform="translate(140 140)">
+    <rect width="1320" height="280" rx="36" fill="url(#card)" />
+    <rect x="72" y="64" width="520" height="48" rx="24" fill="#cbd5f5" />
+    <rect x="72" y="132" width="360" height="32" rx="16" fill="#dbeafe" />
+    <rect x="72" y="188" width="420" height="28" rx="14" fill="#e2e8f0" />
+    <rect x="1080" y="84" width="168" height="56" rx="28" fill="#1e293b" />
+  </g>
+  <g transform="translate(140 472)">
+    <rect width="620" height="388" rx="36" fill="url(#card)" />
+    <rect x="72" y="72" width="476" height="48" rx="24" fill="#bfdbfe" />
+    <rect x="72" y="148" width="476" height="32" rx="16" fill="#e0e7ff" />
+    <rect x="72" y="204" width="380" height="32" rx="16" fill="#e2e8f0" />
+    <rect x="72" y="260" width="420" height="28" rx="14" fill="#f1f5f9" />
+  </g>
+  <g transform="translate(820 472)">
+    <rect width="640" height="388" rx="36" fill="url(#card)" />
+    <rect x="72" y="72" width="220" height="220" rx="24" fill="#c7d2fe" />
+    <rect x="320" y="84" width="240" height="40" rx="20" fill="#bae6fd" />
+    <rect x="320" y="148" width="220" height="32" rx="16" fill="#cbd5f5" />
+    <rect x="320" y="204" width="260" height="32" rx="16" fill="#e0e7ff" />
+    <rect x="320" y="260" width="280" height="28" rx="14" fill="#f1f5f9" />
+  </g>
+</svg>

--- a/tests/hero-cta.spec.ts
+++ b/tests/hero-cta.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test';
+
+test('hero renders with EN by default and CTAs present', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByRole('heading', { name: 'SOCKS5 proxy store' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Buy now' })).toHaveAttribute('href', '/pricing');
+  await expect(page.getByRole('link', { name: 'Contact sales' })).toHaveAttribute('href', '/contact');
+  // badge visible
+  await expect(page.getByText('180+ locations')).toBeVisible();
+});
+
+test('RU locale switches CTA labels', async ({ page }) => {
+  await page.goto('/?lang=ru');
+  await expect(page.getByRole('heading', { name: 'Магазин прокси SOCKS5' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Купить' })).toHaveAttribute('href', '/pricing');
+  await expect(page.getByRole('link', { name: 'Связаться' })).toHaveAttribute('href', '/contact');
+});


### PR DESCRIPTION
## Summary
- replace the homepage hero with a dedicated component that renders i18n copy, dark/light CTA pair, and the static media placeholder
- remove legacy hero layout/styles from the main page and plug the new hero alongside existing sections
- cover the new hero CTAs with Playwright tests for EN default and RU locale labels
- swap the hero placeholder asset to a lightweight SVG to avoid binary diff issues

## Testing
- pnpm lint
- CI=1 pnpm build
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e0f329f194832ab35f96cfab5a5fe6