### PR TITLE
UX polish #8: section separators via background + spacing

### DIFF
--- a/app/page.module.css
+++ b/app/page.module.css
@@ -7,17 +7,6 @@
   scroll-padding-top: clamp(4.5rem, 8vw, 5.25rem);
 }
 
-.section {
-  padding: clamp(3rem, 6vw, 5.5rem) 0;
-}
-
-.sectionInner {
-  width: min(100%, 1120px);
-  margin: 0 auto;
-  padding: 0 clamp(1.5rem, 6vw, 5.5rem);
-  box-sizing: border-box;
-}
-
 .sectionHeader {
   display: grid;
   gap: 0.5rem;
@@ -38,21 +27,13 @@
   line-height: 1.6;
 }
 
-.advantages {
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95) 0%, #eff6ff 100%);
-}
-
-.advantagesInner {
+.advantagesSection {
   display: grid;
   gap: clamp(1.5rem, 3vw, 2.4rem);
   justify-items: center;
 }
 
-.showcase {
-  background: linear-gradient(135deg, #f8fafc 0%, #e0f2fe 45%, #e2e8f0 100%);
-}
-
-.showcaseInner {
+.showcaseSection {
   display: grid;
   gap: clamp(1.8rem, 3vw, 2.6rem);
   justify-items: center;
@@ -146,7 +127,7 @@
   text-align: left;
 }
 
-.advantagesInner .sectionHeader {
+.advantagesSection .sectionHeader {
   text-align: center;
 }
 
@@ -163,12 +144,7 @@
   line-height: 1.5;
 }
 
-.payments {
-  background: linear-gradient(135deg, #0b1220 0%, #172036 100%);
-  color: #f8fafc;
-}
-
-.paymentsInner {
+.paymentsSection {
   display: grid;
   gap: clamp(1.6rem, 3vw, 2.4rem);
   justify-items: center;
@@ -189,7 +165,7 @@
 
 .paymentsDescription {
   margin: 0;
-  color: rgba(248, 250, 252, 0.92);
+  color: #475569;
   line-height: 1.6;
 }
 
@@ -203,11 +179,10 @@
 .paymentBadge {
   padding: 0.55rem 1.3rem;
   border-radius: 999px;
-  background: rgba(248, 250, 252, 0.08);
+  background: #0f172a;
   color: #f8fafc;
   font-weight: 600;
   letter-spacing: 0.01em;
-  backdrop-filter: blur(6px);
 }
 
 @media (max-width: 768px) {
@@ -233,12 +208,3 @@
   }
 }
 
-@media (max-width: 480px) {
-  .section {
-    padding: 2.5rem 0;
-  }
-
-  .sectionInner {
-    padding: 0 1.25rem;
-  }
-}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@
 
 import Hero from "@/components/Hero";
 import TopProductsTabs from "@/components/TopProductsTabs";
+import Section from "@/components/layout/Section";
 import { useI18n } from "@/lib/i18n";
 import type { Locale } from "@/lib/i18n";
 import styles from "./page.module.css";
@@ -139,69 +140,63 @@ export default function Page() {
     <main className={styles.page}>
       <Hero />
 
-      <section className={`${styles.section} ${styles.showcase}`} id="proxy-formats">
-        <div className={`${styles.sectionInner} ${styles.showcaseInner}`}>
-          <div className={`${styles.sectionHeader} ${styles.showcaseHeader}`}>
-            <h2 className={styles.sectionTitle}>{copy.showcase.title}</h2>
-            <p className={styles.sectionDescription}>{copy.showcase.description}</p>
-          </div>
-          <div className={styles.showcaseGrid}>
-            {copy.showcase.items.map(item => (
-              <article key={item.title} className={styles.showcaseCard}>
-                <div className={styles.showcaseCardHeader}>
-                  <h3 className={styles.showcaseCardTitle}>{item.title}</h3>
-                  <span className={styles.showcaseCardPrice}>{item.price}</span>
-                </div>
-                <ul className={styles.showcaseList}>
-                  {item.points.map(point => (
-                    <li key={point}>{point}</li>
-                  ))}
-                </ul>
-              </article>
-            ))}
-          </div>
-          <ul className={styles.showcaseFootnotes} aria-label={copy.showcase.title}>
-            {copy.showcase.metrics.map(metric => (
-              <li key={metric}>{metric}</li>
-            ))}
-          </ul>
+      <Section id="proxy-formats" bg="white" containerClassName={styles.showcaseSection}>
+        <div className={`${styles.sectionHeader} ${styles.showcaseHeader}`}>
+          <h2 className={styles.sectionTitle}>{copy.showcase.title}</h2>
+          <p className={styles.sectionDescription}>{copy.showcase.description}</p>
         </div>
-      </section>
+        <div className={styles.showcaseGrid}>
+          {copy.showcase.items.map(item => (
+            <article key={item.title} className={styles.showcaseCard}>
+              <div className={styles.showcaseCardHeader}>
+                <h3 className={styles.showcaseCardTitle}>{item.title}</h3>
+                <span className={styles.showcaseCardPrice}>{item.price}</span>
+              </div>
+              <ul className={styles.showcaseList}>
+                {item.points.map(point => (
+                  <li key={point}>{point}</li>
+                ))}
+              </ul>
+            </article>
+          ))}
+        </div>
+        <ul className={styles.showcaseFootnotes} aria-label={copy.showcase.title}>
+          {copy.showcase.metrics.map(metric => (
+            <li key={metric}>{metric}</li>
+          ))}
+        </ul>
+      </Section>
 
-      <section className={`${styles.section} ${styles.advantages}`} id="advantages">
-        <div className={`${styles.sectionInner} ${styles.advantagesInner}`}>
-          <div className={styles.sectionHeader}>
-            <h2 className={styles.sectionTitle}>{copy.advantages.title}</h2>
-            <p className={styles.sectionDescription}>{copy.advantages.description}</p>
-          </div>
-          <div className={styles.advantagesGrid}>
-            {copy.advantages.items.map(item => (
-              <article key={item.title} className={styles.advantageCard}>
-                <h3 className={styles.advantageTitle}>{item.title}</h3>
-                <p className={styles.advantageText}>{item.description}</p>
-              </article>
-            ))}
-          </div>
+      <Section id="advantages" bg="muted" containerClassName={styles.advantagesSection}>
+        <div className={styles.sectionHeader}>
+          <h2 className={styles.sectionTitle}>{copy.advantages.title}</h2>
+          <p className={styles.sectionDescription}>{copy.advantages.description}</p>
         </div>
-      </section>
+        <div className={styles.advantagesGrid}>
+          {copy.advantages.items.map(item => (
+            <article key={item.title} className={styles.advantageCard}>
+              <h3 className={styles.advantageTitle}>{item.title}</h3>
+              <p className={styles.advantageText}>{item.description}</p>
+            </article>
+          ))}
+        </div>
+      </Section>
 
       <TopProductsTabs />
 
-      <section className={`${styles.section} ${styles.payments}`} id="payments">
-        <div className={`${styles.sectionInner} ${styles.paymentsInner}`}>
-          <div className={styles.paymentsHeader}>
-            <h2 className={styles.paymentsTitle}>{copy.payments.title}</h2>
-            <p className={styles.paymentsDescription}>{copy.payments.description}</p>
-          </div>
-          <div className={styles.paymentsList}>
-            {copy.payments.methods.map(method => (
-              <span key={method} className={styles.paymentBadge}>
-                {method}
-              </span>
-            ))}
-          </div>
+      <Section id="payments" bg="muted" containerClassName={styles.paymentsSection}>
+        <div className={styles.paymentsHeader}>
+          <h2 className={styles.paymentsTitle}>{copy.payments.title}</h2>
+          <p className={styles.paymentsDescription}>{copy.payments.description}</p>
         </div>
-      </section>
+        <div className={styles.paymentsList}>
+          {copy.payments.methods.map(method => (
+            <span key={method} className={styles.paymentBadge}>
+              {method}
+            </span>
+          ))}
+        </div>
+      </Section>
     </main>
   );
 }

--- a/app/resources/can-i-select-a-proxy-location/page.module.css
+++ b/app/resources/can-i-select-a-proxy-location/page.module.css
@@ -78,7 +78,6 @@
 .footer {
   margin-top: 3rem;
   padding-top: 2rem;
-  border-top: 1px solid rgba(124, 144, 212, 0.25);
   color: rgba(230, 234, 255, 0.85);
   line-height: 1.7;
 }

--- a/app/resources/what-is-a-rotating-proxy/page.module.css
+++ b/app/resources/what-is-a-rotating-proxy/page.module.css
@@ -78,7 +78,6 @@
 .footer {
   margin-top: 3rem;
   padding-top: 2rem;
-  border-top: 1px solid rgba(124, 144, 212, 0.25);
   color: rgba(230, 234, 255, 0.85);
   line-height: 1.7;
 }

--- a/components/PricingTemplate.module.css
+++ b/components/PricingTemplate.module.css
@@ -69,11 +69,7 @@
   box-shadow: 0 10px 25px rgba(79, 70, 229, 0.25);
 }
 
-.plans {
-  padding: 0 1.5rem;
-}
-
-.plansInner {
+.plansSection {
   margin: 0 auto;
   max-width: 1100px;
   display: flex;
@@ -244,7 +240,6 @@
 }
 
 .footer {
-  border-top: 1px solid rgba(148, 163, 184, 0.35);
   padding-top: 1.5rem;
   display: flex;
   flex-direction: column;
@@ -254,7 +249,7 @@
 }
 
 .paymentNote {
-  color: rgba(248, 250, 252, 0.92);
+  color: #475569;
   font-size: 0.95rem;
 }
 
@@ -267,9 +262,8 @@
 
 .paymentChip {
   border-radius: 9999px;
-  background: rgba(148, 163, 184, 0.22);
+  background: #0f172a;
   color: #f8fafc;
-  border: 1px solid rgba(148, 163, 184, 0.35);
   font-weight: 600;
   padding: 0.4rem 1rem;
   font-size: 0.85rem;

--- a/components/PricingTemplate.tsx
+++ b/components/PricingTemplate.tsx
@@ -9,6 +9,7 @@ import { useLocale } from "./LocaleContext";
 import type { Locale } from "./LocaleContext";
 import styles from "./PricingTemplate.module.css";
 import KycNotice from "./KycNotice";
+import Section from "@/components/layout/Section";
 
 type PricingTemplateProps = {
   data: LocalizedPricingPage;
@@ -90,81 +91,79 @@ export default function PricingTemplate({ data }: PricingTemplateProps) {
         </div>
       </section>
 
-      <section className={styles.plans}>
-        <div className={styles.plansInner}>
-          <div className={styles.cardsGrid}>
-            {activeCategory?.tiers.map(tier => {
-              const ribbonPlacement = tier.ribbonPlacement ?? "top";
-              const renderRibbon = (placement: "top" | "bottom") =>
-                tier.ribbon ? (
-                  <span
-                    className={`${styles.planRibbon} ${
-                      placement === "top" ? styles.planRibbonTop : styles.planRibbonBottom
-                    }`}
-                  >
-                    {tier.ribbon}
-                  </span>
-                ) : null;
-              const normalizedRotatingTier =
-                isRotatingPricingPage && activeCategory?.id === "bandwidth"
-                  ? rotatingTierMap.get(tier.id)
-                  : undefined;
-
-              return (
-                <article key={tier.id} className={styles.planCard}>
-                  {ribbonPlacement === "top" && renderRibbon("top")}
-                  <div className={styles.planBody}>
-                    <div className={styles.planHeader}>
-                      <h2 className={styles.planName}>{tier.name}</h2>
-                      {tier.subLabel && <p className={styles.planSubLabel}>{tier.subLabel}</p>}
-                      {tier.headline && <p className={styles.planHeadline}>{tier.headline}</p>}
-                    </div>
-                    <p className={styles.planPrice}>
-                      {normalizedRotatingTier ? (
-                        <span className={styles.rotatingPriceLabel}>
-                          {normalizedRotatingTier.gb} GB — {fmtUSD(Number(normalizedRotatingTier.pricePerGbText))}/GB (Total {fmtUSD(normalizedRotatingTier.total)})
-                        </span>
-                      ) : (
-                        <>
-                          <span className={styles.planPriceValue}>{tier.price}</span>
-                          <span className={styles.planPricePeriod}>{tier.period}</span>
-                        </>
-                      )}
-                    </p>
-                    <ul className={styles.planFeatures}>
-                      {tier.features.map(feature => (
-                        <li key={feature}>{feature}</li>
-                      ))}
-                    </ul>
-                    <KycNotice className={styles.planKycNotice} inline locale={locale} />
-                  </div>
-                  <div className={styles.planFooter}>
-                    <Link
-                      href={tier.ctaHref}
-                      className={styles.planCta}
-                      {...getLinkProps(tier.ctaHref)}
-                    >
-                      {tier.ctaLabel ?? CTA_FALLBACK[locale]}
-                    </Link>
-                    {ribbonPlacement === "bottom" && renderRibbon("bottom")}
-                  </div>
-                </article>
-              );
-            })}
-          </div>
-
-          <footer className={styles.footer}>
-            <p className={styles.paymentNote}>{copy.paymentNote}</p>
-            <div className={styles.paymentMethods} aria-label={PAYMENTS_ARIA_LABEL[locale]}>
-              {copy.paymentMethods.map(method => (
-                <span key={method} className={styles.paymentChip}>
-                  {method}
+      <Section bg="white" containerClassName={styles.plansSection}>
+        <div className={styles.cardsGrid}>
+          {activeCategory?.tiers.map(tier => {
+            const ribbonPlacement = tier.ribbonPlacement ?? "top";
+            const renderRibbon = (placement: "top" | "bottom") =>
+              tier.ribbon ? (
+                <span
+                  className={`${styles.planRibbon} ${
+                    placement === "top" ? styles.planRibbonTop : styles.planRibbonBottom
+                  }`}
+                >
+                  {tier.ribbon}
                 </span>
-              ))}
-            </div>
-          </footer>
+              ) : null;
+            const normalizedRotatingTier =
+              isRotatingPricingPage && activeCategory?.id === "bandwidth"
+                ? rotatingTierMap.get(tier.id)
+                : undefined;
+
+            return (
+              <article key={tier.id} className={styles.planCard}>
+                {ribbonPlacement === "top" && renderRibbon("top")}
+                <div className={styles.planBody}>
+                  <div className={styles.planHeader}>
+                    <h2 className={styles.planName}>{tier.name}</h2>
+                    {tier.subLabel && <p className={styles.planSubLabel}>{tier.subLabel}</p>}
+                    {tier.headline && <p className={styles.planHeadline}>{tier.headline}</p>}
+                  </div>
+                  <p className={styles.planPrice}>
+                    {normalizedRotatingTier ? (
+                      <span className={styles.rotatingPriceLabel}>
+                        {normalizedRotatingTier.gb} GB — {fmtUSD(Number(normalizedRotatingTier.pricePerGbText))}/GB (Total {fmtUSD(normalizedRotatingTier.total)})
+                      </span>
+                    ) : (
+                      <>
+                        <span className={styles.planPriceValue}>{tier.price}</span>
+                        <span className={styles.planPricePeriod}>{tier.period}</span>
+                      </>
+                    )}
+                  </p>
+                  <ul className={styles.planFeatures}>
+                    {tier.features.map(feature => (
+                      <li key={feature}>{feature}</li>
+                    ))}
+                  </ul>
+                  <KycNotice className={styles.planKycNotice} inline locale={locale} />
+                </div>
+                <div className={styles.planFooter}>
+                  <Link
+                    href={tier.ctaHref}
+                    className={styles.planCta}
+                    {...getLinkProps(tier.ctaHref)}
+                  >
+                    {tier.ctaLabel ?? CTA_FALLBACK[locale]}
+                  </Link>
+                  {ribbonPlacement === "bottom" && renderRibbon("bottom")}
+                </div>
+              </article>
+            );
+          })}
         </div>
-      </section>
+
+        <footer className={styles.footer}>
+          <p className={styles.paymentNote}>{copy.paymentNote}</p>
+          <div className={styles.paymentMethods} aria-label={PAYMENTS_ARIA_LABEL[locale]}>
+            {copy.paymentMethods.map(method => (
+              <span key={method} className={styles.paymentChip}>
+                {method}
+              </span>
+            ))}
+          </div>
+        </footer>
+      </Section>
     </main>
   );
 }

--- a/components/ProductTemplate.module.css
+++ b/components/ProductTemplate.module.css
@@ -107,16 +107,7 @@
   display: block;
 }
 
-.offers {
-  padding: clamp(3.5rem, 6vw, 6rem) 0;
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.96) 0%, #eef2ff 100%);
-}
-
-.offersInner {
-  width: min(100%, 1120px);
-  margin: 0 auto;
-  padding: 0 clamp(1.5rem, 6vw, 5.5rem);
-  box-sizing: border-box;
+.offersSection {
   display: grid;
   gap: clamp(2rem, 4vw, 3rem);
   justify-items: center;

--- a/components/ProductTemplate.tsx
+++ b/components/ProductTemplate.tsx
@@ -6,6 +6,7 @@ import type { LocalizedProductPage } from "../lib/productPages";
 import { useLocale } from "./LocaleContext";
 import styles from "./ProductTemplate.module.css";
 import KycNotice from "./KycNotice";
+import Section from "@/components/layout/Section";
 
 function getLinkProps(href: string) {
   if (/^https?:\/\//i.test(href)) {
@@ -90,85 +91,83 @@ export default function ProductTemplate({ data, cardsVariant = "default" }: Prod
         </div>
       </section>
 
-      <section className={styles.offers}>
-        <div className={styles.offersInner}>
-          <header className={styles.offersHeader}>
-            <h2 className={styles.offersTitle}>{copy.offers.title}</h2>
-            {copy.offers.description && <p className={styles.offersDescription}>{copy.offers.description}</p>}
-          </header>
+      <Section bg="white" containerClassName={styles.offersSection}>
+        <header className={styles.offersHeader}>
+          <h2 className={styles.offersTitle}>{copy.offers.title}</h2>
+          {copy.offers.description && <p className={styles.offersDescription}>{copy.offers.description}</p>}
+        </header>
 
-          {isTextLayout ? (
-            <div className={styles.textSections}>
-              {textSections.map(section => (
-                <article key={section.id} className={styles.textSection}>
-                  <h3 className={styles.textSectionTitle}>{section.title}</h3>
-                  <p className={styles.textSectionBody}>{section.body}</p>
-                </article>
-              ))}
-            </div>
-          ) : (
-            <div className={cardsClassName}>
-              {plans.map(plan => (
-                <article
-                  key={plan.id}
-                  className={`${styles.card} ${
-                    plan.badge ? styles.cardFeatured : ""
-                  } ${plan.id === activePlanId ? styles.cardActive : ""}`.trim()}
-                  onClick={() => setActivePlanId(plan.id)}
-                  onKeyDown={handleCardKeyDown(plan.id)}
-                  role="button"
-                  tabIndex={0}
-                  aria-pressed={plan.id === activePlanId}
-                >
-                  <header className={styles.cardHeader}>
-                    <div className={styles.cardTitleRow}>
-                      <h3 className={styles.cardTitle}>{plan.name}</h3>
-                      {plan.badge && <span className={styles.cardBadge}>{plan.badge}</span>}
-                    </div>
-                    <div className={styles.cardPriceBlock}>
-                      {plan.priceLabel && <span className={styles.cardPriceLabel}>{plan.priceLabel}</span>}
-                      <p className={styles.cardPrice}>
-                        {plan.compareAt && <span className={styles.cardCompareAt}>{plan.compareAt}</span>}
-                        <span className={styles.cardPriceValue}>{plan.price}</span>
-                        {plan.period && <span className={styles.cardPricePeriod}>{plan.period}</span>}
-                      </p>
-                    </div>
-                  </header>
+        {isTextLayout ? (
+          <div className={styles.textSections}>
+            {textSections.map(section => (
+              <article key={section.id} className={styles.textSection}>
+                <h3 className={styles.textSectionTitle}>{section.title}</h3>
+                <p className={styles.textSectionBody}>{section.body}</p>
+              </article>
+            ))}
+          </div>
+        ) : (
+          <div className={cardsClassName}>
+            {plans.map(plan => (
+              <article
+                key={plan.id}
+                className={`${styles.card} ${
+                  plan.badge ? styles.cardFeatured : ""
+                } ${plan.id === activePlanId ? styles.cardActive : ""}`.trim()}
+                onClick={() => setActivePlanId(plan.id)}
+                onKeyDown={handleCardKeyDown(plan.id)}
+                role="button"
+                tabIndex={0}
+                aria-pressed={plan.id === activePlanId}
+              >
+                <header className={styles.cardHeader}>
+                  <div className={styles.cardTitleRow}>
+                    <h3 className={styles.cardTitle}>{plan.name}</h3>
+                    {plan.badge && <span className={styles.cardBadge}>{plan.badge}</span>}
+                  </div>
+                  <div className={styles.cardPriceBlock}>
+                    {plan.priceLabel && <span className={styles.cardPriceLabel}>{plan.priceLabel}</span>}
+                    <p className={styles.cardPrice}>
+                      {plan.compareAt && <span className={styles.cardCompareAt}>{plan.compareAt}</span>}
+                      <span className={styles.cardPriceValue}>{plan.price}</span>
+                      {plan.period && <span className={styles.cardPricePeriod}>{plan.period}</span>}
+                    </p>
+                  </div>
+                </header>
 
-                  {plan.summary && <p className={styles.cardSummary}>{plan.summary}</p>}
+                {plan.summary && <p className={styles.cardSummary}>{plan.summary}</p>}
 
-                  <ul className={styles.cardFeatures}>
-                    {plan.features.map(feature => {
-                      const included = feature.included ?? true;
-                      return (
-                        <li
-                          key={feature.label}
-                          className={`${styles.cardFeature} ${
-                            included ? styles.featureIncluded : styles.featureExcluded
-                          }`}
-                        >
-                          <span className={styles.featureIcon} aria-hidden="true">
-                            {included ? "✓" : "✕"}
-                          </span>
-                          <span>{feature.label}</span>
-                        </li>
-                      );
-                    })}
-                  </ul>
+                <ul className={styles.cardFeatures}>
+                  {plan.features.map(feature => {
+                    const included = feature.included ?? true;
+                    return (
+                      <li
+                        key={feature.label}
+                        className={`${styles.cardFeature} ${
+                          included ? styles.featureIncluded : styles.featureExcluded
+                        }`}
+                      >
+                        <span className={styles.featureIcon} aria-hidden="true">
+                          {included ? "✓" : "✕"}
+                        </span>
+                        <span>{feature.label}</span>
+                      </li>
+                    );
+                  })}
+                </ul>
 
-                  <KycNotice className={styles.cardKycNotice} inline locale={locale} />
+                <KycNotice className={styles.cardKycNotice} inline locale={locale} />
 
-                  <Link href={plan.ctaHref} className={styles.cardCta} {...getLinkProps(plan.ctaHref)}>
-                    {plan.ctaLabel}
-                  </Link>
-                </article>
-              ))}
-            </div>
-          )}
+                <Link href={plan.ctaHref} className={styles.cardCta} {...getLinkProps(plan.ctaHref)}>
+                  {plan.ctaLabel}
+                </Link>
+              </article>
+            ))}
+          </div>
+        )}
 
-          {copy.offers.note && <p className={styles.offersNote}>{copy.offers.note}</p>}
-        </div>
-      </section>
+        {copy.offers.note && <p className={styles.offersNote}>{copy.offers.note}</p>}
+      </Section>
     </main>
   );
 }

--- a/components/TopProductsTabs.tsx
+++ b/components/TopProductsTabs.tsx
@@ -5,6 +5,7 @@ import Tabs from "@/components/ui/Tabs";
 import StaticIspCard from "@/components/products/StaticIspCard";
 import StaticIpv6Card from "@/components/products/StaticIpv6Card";
 import RotatingResidentialCard from "@/components/products/RotatingResidentialCard";
+import Section from "@/components/layout/Section";
 import { useI18n } from "@/lib/i18n";
 
 export default function TopProductsTabs() {
@@ -19,13 +20,9 @@ export default function TopProductsTabs() {
   );
 
   return (
-    <section
-      aria-labelledby="top-products-heading"
-      className="py-12"
-      style={{ backgroundColor: "#ffffff" }}
-    >
-      <div style={{ maxWidth: "1120px", margin: "0 auto", padding: "0 24px" }}>
-        <h2 id="top-products-heading" style={{ fontSize: "2rem", fontWeight: 600, margin: "0 0 1rem" }}>
+    <Section aria-labelledby="top-products-heading" bg="white">
+      <div style={{ display: "grid", gap: "1.5rem" }}>
+        <h2 id="top-products-heading" style={{ fontSize: "2rem", fontWeight: 600, margin: 0 }}>
           {t("topProducts.title", "Top Products by SoksLine")}
         </h2>
 
@@ -39,6 +36,6 @@ export default function TopProductsTabs() {
           }}
         />
       </div>
-    </section>
+    </Section>
   );
 }

--- a/components/layout/Section.tsx
+++ b/components/layout/Section.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import clsx from "clsx";
+
+/**
+ * Разделение крупных блоков — только фоном (bg-white/bg-gray-50) и вертикальными отступами (py-*).
+ * Не использовать бордеры/<hr> для секций.
+ */
+type Props = React.HTMLAttributes<HTMLElement> & {
+  bg?: "white" | "muted";
+  id?: string;
+  className?: string;
+  containerClassName?: string;
+  children: React.ReactNode;
+};
+
+export default function Section({
+  bg = "white",
+  id,
+  className = "",
+  containerClassName = "",
+  children,
+  ...rest
+}: Props) {
+  const variant = bg === "muted" ? "muted" : "white";
+
+  return (
+    <section
+      id={id}
+      data-variant={variant}
+      className={clsx(
+        variant === "muted" ? "bg-gray-50" : "bg-white",
+        "py-12 sm:py-16",
+        className
+      )}
+      {...rest}
+    >
+      <div className={clsx("mx-auto max-w-6xl px-4", containerClassName)}>{children}</div>
+    </section>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "dependencies": {
     "next": "^15.5.4",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "clsx": "^2.1.1"
   },
   "scripts": {
     "dev": "next dev",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       next:
         specifier: ^15.5.4
         version: 15.5.4(@playwright/test@1.55.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -1066,6 +1069,10 @@ packages:
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -3249,6 +3256,8 @@ snapshots:
   check-error@2.1.1: {}
 
   client-only@0.0.1: {}
+
+  clsx@2.1.1: {}
 
   color-convert@2.0.1:
     dependencies:

--- a/tests/sections.spec.ts
+++ b/tests/sections.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from "@playwright/test";
+
+test("sections alternate backgrounds and contain no hr elements", async ({ page }) => {
+  await page.goto("/");
+
+  const hrs = await page.locator("hr").count();
+  expect(hrs).toBe(0);
+
+  const sections = page.locator("section");
+  const count = await sections.count();
+  expect(count).toBeGreaterThan(1);
+
+  const hasMuted = await page.locator("section.bg-gray-50, section[data-variant='muted']").count();
+  const hasWhite = await page.locator("section.bg-white, section[data-variant='white']").count();
+  expect(hasMuted).toBeGreaterThan(0);
+  expect(hasWhite).toBeGreaterThan(0);
+});


### PR DESCRIPTION
## Summary
- add a reusable Section layout wrapper that alternates backgrounds and documents the spacing guidance
- refactor the home, product, and pricing templates to compose sections with the new wrapper and remove decorative borders in resource footers
- update styles and add a Playwright smoke test to ensure section backgrounds alternate without relying on hr elements

## Testing
- pnpm lint
- pnpm test
- npx playwright test tests/sections.spec.ts --workers=1 *(fails: requires browser install in CI)*

------
https://chatgpt.com/codex/tasks/task_e_68e0ff406eb8832aabc0bfbc51ccde68