### PR TITLE
UX polish #9: a11y structure (H1/alt/aria-current/skip-link/forms)

### DIFF
--- a/app/aml/page.tsx
+++ b/app/aml/page.tsx
@@ -6,9 +6,11 @@ import LanguageSwitcher from '@/components/LanguageSwitcher';
 export default function Page() {
   const { t } = useI18n();
   return (
-    <main className="max-w-3xl mx-auto px-4 py-10">
+    <section className="max-w-3xl mx-auto px-4 py-10" aria-labelledby="aml-heading">
       <div className="flex items-center justify-between mb-6">
-        <h1 className="text-3xl font-semibold">{t('pages.aml.title')}</h1>
+        <h1 id="aml-heading" className="text-3xl font-semibold">
+          {t('pages.aml.title')}
+        </h1>
         <LanguageSwitcher />
       </div>
       <p className="opacity-80 mb-4">{t('pages.aml.intro')}</p>
@@ -16,6 +18,6 @@ export default function Page() {
       <p className="opacity-80">{t('pages.aml.section1.text')}</p>
       <h2 className="text-xl font-medium mt-8 mb-2">{t('pages.aml.section2.title')}</h2>
       <p className="opacity-80">{t('pages.aml.section2.text')}</p>
-    </main>
+    </section>
   );
 }

--- a/app/aup/page.tsx
+++ b/app/aup/page.tsx
@@ -6,13 +6,15 @@ import LanguageSwitcher from '@/components/LanguageSwitcher';
 export default function Page() {
   const { t } = useI18n();
   return (
-    <main className="max-w-3xl mx-auto px-4 py-10">
+    <section className="max-w-3xl mx-auto px-4 py-10" aria-labelledby="aup-heading">
       <div className="flex items-center justify-between mb-6">
-        <h1 className="text-3xl font-semibold">{t('pages.aup.title')}</h1>
+        <h1 id="aup-heading" className="text-3xl font-semibold">
+          {t('pages.aup.title')}
+        </h1>
         <LanguageSwitcher />
       </div>
       <p className="opacity-80 mb-4">{t('pages.aup.intro')}</p>
       <p className="opacity-60">{t('pages.shared.comingSoon')}</p>
-    </main>
+    </section>
   );
 }

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -6,24 +6,48 @@ import LanguageSwitcher from '@/components/LanguageSwitcher';
 export default function Page() {
   const { t } = useI18n();
   return (
-    <main className="max-w-3xl mx-auto px-4 py-10">
+    <section className="max-w-3xl mx-auto px-4 py-10" aria-labelledby="contact-heading">
       <div className="flex items-center justify-between mb-6">
-        <h1 className="text-3xl font-semibold">{t('pages.contact.title')}</h1>
+        <h1 id="contact-heading" className="text-3xl font-semibold">
+          {t('pages.contact.title')}
+        </h1>
         <LanguageSwitcher />
       </div>
       <p className="opacity-80">{t('pages.contact.intro')}</p>
       <form className="mt-6 grid gap-4 max-w-xl">
-        <input className="border rounded p-3" placeholder={t('pages.contact.name')} />
-        <input className="border rounded p-3" placeholder={t('pages.contact.email')} />
-        <textarea
-          className="border rounded p-3"
-          rows={5}
-          placeholder={t('pages.contact.msg')}
+        <label htmlFor="c-name" className="text-sm font-medium">
+          {t('pages.contact.name')}
+        </label>
+        <input
+          id="c-name"
+          name="name"
+          className="border rounded p-3 focus:outline-none focus-visible:ring focus-visible:ring-offset-2"
         />
-        <button type="button" className="px-4 py-2 rounded bg-gray-900 text-white">
+        <label htmlFor="c-email" className="text-sm font-medium">
+          {t('pages.contact.email')}
+        </label>
+        <input
+          id="c-email"
+          name="email"
+          inputMode="email"
+          className="border rounded p-3 focus:outline-none focus-visible:ring focus-visible:ring-offset-2"
+        />
+        <label htmlFor="c-msg" className="text-sm font-medium">
+          {t('pages.contact.msg')}
+        </label>
+        <textarea
+          id="c-msg"
+          name="message"
+          className="border rounded p-3 focus:outline-none focus-visible:ring focus-visible:ring-offset-2"
+          rows={5}
+        />
+        <button
+          type="button"
+          className="px-4 py-2 rounded bg-gray-900 text-white focus:outline-none focus-visible:ring focus-visible:ring-offset-2"
+        >
           {t('pages.contact.submit')}
         </button>
       </form>
-    </main>
+    </section>
   );
 }

--- a/app/help-center/HelpCenterPage.tsx
+++ b/app/help-center/HelpCenterPage.tsx
@@ -90,7 +90,7 @@ export default function HelpCenterPage() {
   };
 
   return (
-    <main className={styles.page}>
+    <div className={styles.page}>
       <section className={styles.panel} aria-labelledby="help-center-title">
         <header className={styles.header}>
           <h1 id="help-center-title" className={styles.title}>
@@ -149,6 +149,6 @@ export default function HelpCenterPage() {
           </button>
         </form>
       </section>
-    </main>
+    </div>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import React, { Suspense } from "react";
 import HeaderNav from "@/components/HeaderNav";
 import Footer from "@/components/Footer";
+import SkipLink from "@/components/a11y/SkipLink";
 import { I18nProvider } from "@/lib/i18n";
 
 export const metadata = { title: "SoksLine", description: "Proxy store" };
@@ -11,8 +12,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body style={{ fontFamily: "system-ui, sans-serif", margin: 0, backgroundColor: "#0b1220" }}>
         <Suspense fallback={null}>
           <I18nProvider>
-            <HeaderNav />
-            {children}
+            <SkipLink />
+            <header role="banner">
+              <HeaderNav />
+            </header>
+            <main id="main-content" tabIndex={-1}>
+              {children}
+            </main>
             <Footer />
           </I18nProvider>
         </Suspense>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -6,23 +6,40 @@ import LanguageSwitcher from '@/components/LanguageSwitcher';
 export default function Page() {
   const { t } = useI18n();
   return (
-    <main className="max-w-3xl mx-auto px-4 py-10">
+    <section className="max-w-3xl mx-auto px-4 py-10" aria-labelledby="login-heading">
       <div className="flex items-center justify-between mb-6">
-        <h1 className="text-3xl font-semibold">{t('pages.login.title')}</h1>
+        <h1 id="login-heading" className="text-3xl font-semibold">
+          {t('pages.login.title')}
+        </h1>
         <LanguageSwitcher />
       </div>
       <p className="opacity-80">{t('pages.login.intro')}</p>
       <form className="mt-6 grid gap-4 max-w-sm">
-        <input className="border rounded p-3" placeholder={t('pages.login.email')} />
+        <label htmlFor="l-email" className="text-sm font-medium">
+          {t('pages.login.email')}
+        </label>
         <input
-          className="border rounded p-3"
-          type="password"
-          placeholder={t('pages.login.password')}
+          id="l-email"
+          name="email"
+          inputMode="email"
+          className="border rounded p-3 focus:outline-none focus-visible:ring focus-visible:ring-offset-2"
         />
-        <button type="button" className="px-4 py-2 rounded bg-gray-900 text-white">
+        <label htmlFor="l-pass" className="text-sm font-medium">
+          {t('pages.login.password')}
+        </label>
+        <input
+          id="l-pass"
+          name="password"
+          type="password"
+          className="border rounded p-3 focus:outline-none focus-visible:ring focus-visible:ring-offset-2"
+        />
+        <button
+          type="button"
+          className="px-4 py-2 rounded bg-gray-900 text-white focus:outline-none focus-visible:ring focus-visible:ring-offset-2"
+        >
           {t('pages.login.signIn')}
         </button>
       </form>
-    </main>
+    </section>
   );
 }

--- a/app/order/OrderPageContent.tsx
+++ b/app/order/OrderPageContent.tsx
@@ -213,7 +213,7 @@ export default function OrderPageContent() {
     : activeTier?.price ?? "—";
 
   return (
-    <main className={styles.page}>
+    <div className={styles.page}>
       <div className={styles.layout}>
         <div className={styles.contentColumn}>
           <section className={styles.hero}>
@@ -577,6 +577,6 @@ export default function OrderPageContent() {
           </div>
         </aside>
       </div>
-    </main>
+    </div>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -137,7 +137,7 @@ export default function Page() {
   const copy = HOME_CONTENT[locale];
 
   return (
-    <main className={styles.page}>
+    <div className={styles.page}>
       <Hero />
 
       <Section id="proxy-formats" bg="white" containerClassName={styles.showcaseSection}>
@@ -197,6 +197,6 @@ export default function Page() {
           ))}
         </div>
       </Section>
-    </main>
+    </div>
   );
 }

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -6,13 +6,15 @@ import LanguageSwitcher from '@/components/LanguageSwitcher';
 export default function Page() {
   const { t } = useI18n();
   return (
-    <main className="max-w-3xl mx-auto px-4 py-10">
+    <section className="max-w-3xl mx-auto px-4 py-10" aria-labelledby="privacy-heading">
       <div className="flex items-center justify-between mb-6">
-        <h1 className="text-3xl font-semibold">{t('pages.privacy.title')}</h1>
+        <h1 id="privacy-heading" className="text-3xl font-semibold">
+          {t('pages.privacy.title')}
+        </h1>
         <LanguageSwitcher />
       </div>
       <p className="opacity-80 mb-4">{t('pages.privacy.intro')}</p>
       <p className="opacity-60">{t('pages.shared.comingSoon')}</p>
-    </main>
+    </section>
   );
 }

--- a/app/refund/page.tsx
+++ b/app/refund/page.tsx
@@ -6,13 +6,15 @@ import LanguageSwitcher from '@/components/LanguageSwitcher';
 export default function Page() {
   const { t } = useI18n();
   return (
-    <main className="max-w-3xl mx-auto px-4 py-10">
+    <section className="max-w-3xl mx-auto px-4 py-10" aria-labelledby="refund-heading">
       <div className="flex items-center justify-between mb-6">
-        <h1 className="text-3xl font-semibold">{t('pages.refund.title')}</h1>
+        <h1 id="refund-heading" className="text-3xl font-semibold">
+          {t('pages.refund.title')}
+        </h1>
         <LanguageSwitcher />
       </div>
       <p className="opacity-80 mb-4">{t('pages.refund.intro')}</p>
       <p className="opacity-60">{t('pages.shared.comingSoon')}</p>
-    </main>
+    </section>
   );
 }

--- a/app/resources/can-i-select-a-proxy-location/page.client.tsx
+++ b/app/resources/can-i-select-a-proxy-location/page.client.tsx
@@ -77,7 +77,7 @@ export default function PageClient() {
   const content = CONTENT[locale];
 
   return (
-    <main className={styles.page}>
+    <div className={styles.page}>
       <article className={styles.article}>
         <header className={styles.header}>
           <span className={styles.eyebrow}>{content.eyebrow}</span>
@@ -101,6 +101,6 @@ export default function PageClient() {
           <p>{content.footer}</p>
         </footer>
       </article>
-    </main>
+    </div>
   );
 }

--- a/app/resources/how-long-to-receive-my-ordered-proxies/page.client.tsx
+++ b/app/resources/how-long-to-receive-my-ordered-proxies/page.client.tsx
@@ -36,7 +36,7 @@ export default function PageClient() {
   const content = CONTENT[locale];
 
   return (
-    <main className={styles.page}>
+    <div className={styles.page}>
       <article className={styles.article}>
         <header className={styles.header}>
           <span className={styles.eyebrow}>{content.eyebrow}</span>
@@ -50,6 +50,6 @@ export default function PageClient() {
           ))}
         </section>
       </article>
-    </main>
+    </div>
   );
 }

--- a/app/resources/what-are-the-targeting-options-for-our-proxies/page.client.tsx
+++ b/app/resources/what-are-the-targeting-options-for-our-proxies/page.client.tsx
@@ -199,7 +199,7 @@ export default function PageClient() {
   const content = CONTENT[locale];
 
   return (
-    <main className={styles.page}>
+    <div className={styles.page}>
       <article className={styles.article}>
         <header className={styles.header}>
           <span className={styles.eyebrow}>{content.eyebrow}</span>
@@ -258,6 +258,6 @@ export default function PageClient() {
           <p className={styles.note}>{content.note}</p>
         </section>
       </article>
-    </main>
+    </div>
   );
 }

--- a/app/resources/what-is-a-rotating-proxy/page.client.tsx
+++ b/app/resources/what-is-a-rotating-proxy/page.client.tsx
@@ -74,7 +74,7 @@ export default function PageClient() {
   const content = CONTENT[locale];
 
   return (
-    <main className={styles.page}>
+    <div className={styles.page}>
       <article className={styles.article}>
         <header className={styles.header}>
           <span className={styles.eyebrow}>{content.eyebrow}</span>
@@ -102,6 +102,6 @@ export default function PageClient() {
           <p>{content.footer}</p>
         </footer>
       </article>
-    </main>
+    </div>
   );
 }

--- a/app/resources/what-solutions-do-you-offer/page.client.tsx
+++ b/app/resources/what-solutions-do-you-offer/page.client.tsx
@@ -70,7 +70,7 @@ export default function PageClient() {
   const content = CONTENT[locale];
 
   return (
-    <main className={styles.page}>
+    <div className={styles.page}>
       <article className={styles.article}>
         <header className={styles.header}>
           <span className={styles.eyebrow}>{content.eyebrow}</span>
@@ -90,6 +90,6 @@ export default function PageClient() {
           </ul>
         </section>
       </article>
-    </main>
+    </div>
   );
 }

--- a/app/resources/why-residential-proxies/page.client.tsx
+++ b/app/resources/why-residential-proxies/page.client.tsx
@@ -55,7 +55,7 @@ export default function PageClient() {
   const content = CONTENT[locale];
 
   return (
-    <main className={styles.page}>
+    <div className={styles.page}>
       <article className={styles.article}>
         <header className={styles.header}>
           <span className={styles.eyebrow}>{content.eyebrow}</span>
@@ -79,6 +79,6 @@ export default function PageClient() {
           </ul>
         </section>
       </article>
-    </main>
+    </div>
   );
 }

--- a/app/tos/page.tsx
+++ b/app/tos/page.tsx
@@ -6,13 +6,15 @@ import LanguageSwitcher from '@/components/LanguageSwitcher';
 export default function Page() {
   const { t } = useI18n();
   return (
-    <main className="max-w-3xl mx-auto px-4 py-10">
+    <section className="max-w-3xl mx-auto px-4 py-10" aria-labelledby="tos-heading">
       <div className="flex items-center justify-between mb-6">
-        <h1 className="text-3xl font-semibold">{t('pages.tos.title')}</h1>
+        <h1 id="tos-heading" className="text-3xl font-semibold">
+          {t('pages.tos.title')}
+        </h1>
         <LanguageSwitcher />
       </div>
       <p className="opacity-80 mb-4">{t('pages.tos.intro')}</p>
       <p className="opacity-60">{t('pages.shared.comingSoon')}</p>
-    </main>
+    </section>
   );
 }

--- a/components/ExternalLink.tsx
+++ b/components/ExternalLink.tsx
@@ -23,7 +23,7 @@ export default function ExternalLink({
       className={`inline-flex items-center gap-1 ${className}`}
     >
       {children}
-      <span aria-hidden>↗</span>
+      <span aria-hidden="true">↗</span>
     </Link>
   );
 }

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,9 +1,8 @@
 'use client';
 
 import React from 'react';
-import Link from 'next/link';
-import { usePathname } from 'next/navigation';
 import { useI18n } from '@/lib/i18n';
+import NavLink from './NavLink';
 
 const NAV_ITEMS: { key: `nav.${string}`; href: string }[] = [
   { key: 'nav.pricing', href: '/pricing' },
@@ -19,10 +18,22 @@ const NAV_ITEMS: { key: `nav.${string}`; href: string }[] = [
 export default function Footer() {
   const { t } = useI18n();
   const year = new Date().getFullYear();
-  const pathname = usePathname();
+
+  const linkBaseStyle: React.CSSProperties = {
+    color: 'rgba(226, 232, 240, 0.75)',
+    textDecoration: 'none',
+    fontWeight: 400,
+    transition: 'color 0.2s ease',
+  };
+
+  const linkActiveStyle: React.CSSProperties = {
+    color: '#f8fafc',
+    fontWeight: 600,
+  };
 
   return (
     <footer
+      role="contentinfo"
       style={{
         backgroundColor: '#0b1220',
         color: 'rgba(226, 232, 240, 0.7)',
@@ -55,26 +66,17 @@ export default function Footer() {
               padding: 0,
             }}
           >
-            {NAV_ITEMS.map(item => {
-              const isActive = pathname === item.href;
-
-              return (
-                <li key={item.key}>
-                  <Link
-                    href={item.href}
-                    aria-current={isActive ? 'page' : undefined}
-                    style={{
-                      color: isActive ? '#f8fafc' : 'rgba(226, 232, 240, 0.75)',
-                      textDecoration: 'none',
-                      fontWeight: isActive ? 600 : 400,
-                      transition: 'color 0.2s ease',
-                    }}
-                  >
-                    {t(item.key)}
-                  </Link>
-                </li>
-              );
-            })}
+            {NAV_ITEMS.map(item => (
+              <li key={item.key}>
+                <NavLink
+                  href={item.href}
+                  style={linkBaseStyle}
+                  activeStyle={linkActiveStyle}
+                >
+                  {t(item.key)}
+                </NavLink>
+              </li>
+            ))}
           </ul>
         </nav>
       </div>

--- a/components/HeaderNav.tsx
+++ b/components/HeaderNav.tsx
@@ -1,11 +1,10 @@
 'use client';
 
 import React from 'react';
-import Link from 'next/link';
-import { usePathname } from 'next/navigation';
 import LanguageSwitcher from '@/components/LanguageSwitcher';
 import { useI18n } from '@/lib/i18n';
 import styles from './HeaderNav.module.css';
+import NavLink from './NavLink';
 
 type NavItem = {
   key: `nav.${string}`;
@@ -24,32 +23,25 @@ const NAV_ITEMS: NavItem[] = [
 
 export default function HeaderNav() {
   const { t } = useI18n();
-  const pathname = usePathname();
 
   return (
-    <header className={styles.wrapper}>
+    <div className={styles.wrapper}>
       <div className={styles.inner}>
-        <Link href="/" className={styles.brand}>
+        <NavLink href="/" className={styles.brand}>
           <span className={styles.brandMark} aria-hidden="true">
             S
           </span>
           <span>{t('brand')}</span>
-        </Link>
+        </NavLink>
 
-        <nav className={styles.nav} aria-label="Main">
+        <nav className={styles.nav} aria-label="Primary">
           <ul className={styles.navList}>
             {NAV_ITEMS.map(item => {
-              const isActive = pathname === item.href;
-
               return (
                 <li key={item.key}>
-                  <Link
-                    href={item.href}
-                    className={styles.navLink}
-                    aria-current={isActive ? 'page' : undefined}
-                  >
+                  <NavLink href={item.href} className={styles.navLink}>
                     {t(item.key)}
-                  </Link>
+                  </NavLink>
                 </li>
               );
             })}
@@ -58,15 +50,11 @@ export default function HeaderNav() {
 
         <div className={styles.actions}>
           <LanguageSwitcher />
-          <Link
-            href="/login"
-            className={styles.login}
-            aria-current={pathname === '/login' ? 'page' : undefined}
-          >
+          <NavLink href="/login" className={styles.login}>
             {t('nav.login')}
-          </Link>
+          </NavLink>
         </div>
       </div>
-    </header>
+    </div>
   );
 }

--- a/components/LanguageSwitcher.tsx
+++ b/components/LanguageSwitcher.tsx
@@ -23,12 +23,18 @@ export default function LanguageSwitcher({ className = '' }: { className?: strin
   };
 
   return (
-    <div className={className} style={{ display: 'inline-flex', alignItems: 'center', gap: '0.35rem' }} aria-label="Language">
+    <div
+      className={className}
+      role="group"
+      aria-label="Language"
+      style={{ display: 'inline-flex', alignItems: 'center', gap: '0.35rem' }}
+    >
       <button
         type="button"
         onClick={() => setLocale('en')}
         aria-pressed={locale === 'en'}
         style={{ ...baseStyle, ...(locale === 'en' ? activeStyle : {}) }}
+        className="focus:outline-none focus-visible:ring focus-visible:ring-offset-2"
       >
         EN
       </button>
@@ -37,6 +43,7 @@ export default function LanguageSwitcher({ className = '' }: { className?: strin
         onClick={() => setLocale('ru')}
         aria-pressed={locale === 'ru'}
         style={{ ...baseStyle, ...(locale === 'ru' ? activeStyle : {}) }}
+        className="focus:outline-none focus-visible:ring focus-visible:ring-offset-2"
       >
         RU
       </button>

--- a/components/NavLink.tsx
+++ b/components/NavLink.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import clsx from 'clsx';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import type { ComponentProps, CSSProperties, ReactNode } from 'react';
+
+interface NavLinkProps extends Omit<ComponentProps<typeof Link>, 'href' | 'className' | 'children'> {
+  href: string;
+  children: ReactNode;
+  className?: string;
+  activeClassName?: string;
+  inactiveClassName?: string;
+  style?: CSSProperties;
+  activeStyle?: CSSProperties;
+  inactiveStyle?: CSSProperties;
+}
+
+export default function NavLink({
+  href,
+  children,
+  className,
+  activeClassName,
+  inactiveClassName,
+  style,
+  activeStyle,
+  inactiveStyle,
+  ...rest
+}: NavLinkProps) {
+  const pathname = usePathname();
+  const isActive = pathname === href || (href !== '/' && pathname.startsWith(href));
+  const classNames = clsx(className, isActive ? activeClassName : inactiveClassName);
+  const stateStyle = (isActive ? activeStyle : inactiveStyle) ?? undefined;
+  const mergedStyle: CSSProperties | undefined =
+    style || stateStyle
+      ? { ...(style ?? {}), ...(stateStyle ?? {}) }
+      : undefined;
+
+  return (
+    <Link
+      href={href}
+      aria-current={isActive ? 'page' : undefined}
+      className={classNames}
+      style={mergedStyle}
+      {...rest}
+    >
+      {children}
+    </Link>
+  );
+}

--- a/components/PricingTemplate.tsx
+++ b/components/PricingTemplate.tsx
@@ -62,7 +62,7 @@ export default function PricingTemplate({ data }: PricingTemplateProps) {
   };
 
   return (
-    <main className={styles.page}>
+    <div className={styles.page}>
       <section className={styles.hero}>
         <div className={styles.heroInner}>
           <p className={styles.heroHighlight}>{copy.highlight}</p>
@@ -164,6 +164,6 @@ export default function PricingTemplate({ data }: PricingTemplateProps) {
           </div>
         </footer>
       </Section>
-    </main>
+    </div>
   );
 }

--- a/components/ProductTemplate.tsx
+++ b/components/ProductTemplate.tsx
@@ -55,7 +55,7 @@ export default function ProductTemplate({ data, cardsVariant = "default" }: Prod
   };
 
   return (
-    <main className={styles.page}>
+    <div className={styles.page}>
       <section className={styles.hero}>
         <div className={styles.heroInner}>
           {copy.hero.eyebrow && <p className={styles.heroEyebrow}>{copy.hero.eyebrow}</p>}
@@ -168,6 +168,6 @@ export default function ProductTemplate({ data, cardsVariant = "default" }: Prod
 
         {copy.offers.note && <p className={styles.offersNote}>{copy.offers.note}</p>}
       </Section>
-    </main>
+    </div>
   );
 }

--- a/components/a11y/SkipLink.tsx
+++ b/components/a11y/SkipLink.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+export default function SkipLink() {
+  return (
+    <a
+      href="#main-content"
+      className="sr-only focus:not-sr-only fixed top-2 left-2 z-50 rounded bg-gray-900 px-3 py-2 text-white"
+    >
+      Skip to content
+    </a>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable skip link and landmark structure to the root layout for better keyboard navigation
- consolidate navigation links with aria-current styling in the header and footer, and tighten icon/alt handling
- update marketing, legal, and auth pages to expose a single H1 and labelled form controls instead of placeholder-only inputs

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e10294efbc832a9b270275c89fb6b9