### PR TITLE
Update i18n CTA selectors to match link markup

### DIFF
--- a/tests/i18n.spec.ts
+++ b/tests/i18n.spec.ts
@@ -3,15 +3,15 @@ import { test, expect } from '@playwright/test';
 test('i18n switch persists', async ({ page }) => {
   await page.goto('/');
 
-  await expect(page.getByRole('button', { name: 'Buy now' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Buy now' })).toBeVisible();
 
   await page.getByRole('button', { name: 'RU' }).click();
-  await expect(page.getByRole('button', { name: 'Купить' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Купить' })).toBeVisible();
   await page.reload();
-  await expect(page.getByRole('button', { name: 'Купить' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Купить' })).toBeVisible();
   await expect(page).toHaveURL(/lang=ru/);
 
   await page.getByRole('button', { name: 'EN' }).click();
-  await expect(page.getByRole('button', { name: 'Buy now' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Buy now' })).toBeVisible();
   await expect(page).toHaveURL(/lang=en/);
 });


### PR DESCRIPTION
## Summary
- update the i18n persistence Playwright test to look for the hero CTA as a link in both EN and RU locales

## Testing
- PLAYWRIGHT_TEST_BASE_URL=http://127.0.0.1:3000 pnpm exec playwright test tests/i18n.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e10ecfe0e0832a9a927b7ef4826cd4