### PR TITLE
Hotfix: hero CTA, skip-link, tabs, contact layout, legal ToC, KYC icon

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,53 +1,56 @@
 'use client';
 
-import { useI18n } from '@/lib/i18n';
+import Section from '@/components/layout/Section';
 import LanguageSwitcher from '@/components/LanguageSwitcher';
+import { useI18n } from '@/lib/i18n';
 
 export default function Page() {
   const { t } = useI18n();
   return (
-    <section className="max-w-3xl mx-auto px-4 py-10" aria-labelledby="contact-heading">
-      <div className="flex items-center justify-between mb-6">
-        <h1 id="contact-heading" className="text-3xl font-semibold">
-          {t('pages.contact.title')}
-        </h1>
-        <LanguageSwitcher />
+    <Section bg="white" aria-labelledby="contact-heading" containerClassName="not-prose">
+      <div className="mx-auto flex max-w-3xl flex-col gap-6">
+        <div className="flex items-center justify-between gap-4">
+          <h1 id="contact-heading" className="text-3xl font-semibold">
+            {t('pages.contact.title')}
+          </h1>
+          <LanguageSwitcher />
+        </div>
+        <p className="opacity-80">{t('pages.contact.intro')}</p>
+        <form className="mt-2 grid max-w-xl gap-4">
+          <label htmlFor="c-name" className="block text-sm font-medium">
+            {t('pages.contact.name')}
+            <input
+              id="c-name"
+              name="name"
+              className="mt-1 w-full rounded border border-gray-300 p-3 focus:outline-none focus-visible:ring focus-visible:ring-offset-2"
+            />
+          </label>
+          <label htmlFor="c-email" className="block text-sm font-medium">
+            {t('pages.contact.email')}
+            <input
+              id="c-email"
+              name="email"
+              inputMode="email"
+              className="mt-1 w-full rounded border border-gray-300 p-3 focus:outline-none focus-visible:ring focus-visible:ring-offset-2"
+            />
+          </label>
+          <label htmlFor="c-msg" className="block text-sm font-medium">
+            {t('pages.contact.msg')}
+            <textarea
+              id="c-msg"
+              name="message"
+              rows={5}
+              className="mt-1 w-full rounded border border-gray-300 p-3 focus:outline-none focus-visible:ring focus-visible:ring-offset-2"
+            />
+          </label>
+          <button
+            type="button"
+            className="inline-flex items-center justify-center rounded-2xl border border-transparent bg-gray-900 px-5 py-3 text-base font-medium text-white hover:bg-black focus:outline-none focus-visible:ring focus-visible:ring-offset-2"
+          >
+            {t('pages.contact.submit')}
+          </button>
+        </form>
       </div>
-      <p className="opacity-80">{t('pages.contact.intro')}</p>
-      <form className="mt-6 grid gap-4 max-w-xl">
-        <label htmlFor="c-name" className="text-sm font-medium">
-          {t('pages.contact.name')}
-        </label>
-        <input
-          id="c-name"
-          name="name"
-          className="border rounded p-3 focus:outline-none focus-visible:ring focus-visible:ring-offset-2"
-        />
-        <label htmlFor="c-email" className="text-sm font-medium">
-          {t('pages.contact.email')}
-        </label>
-        <input
-          id="c-email"
-          name="email"
-          inputMode="email"
-          className="border rounded p-3 focus:outline-none focus-visible:ring focus-visible:ring-offset-2"
-        />
-        <label htmlFor="c-msg" className="text-sm font-medium">
-          {t('pages.contact.msg')}
-        </label>
-        <textarea
-          id="c-msg"
-          name="message"
-          className="border rounded p-3 focus:outline-none focus-visible:ring focus-visible:ring-offset-2"
-          rows={5}
-        />
-        <button
-          type="button"
-          className="px-4 py-2 rounded bg-gray-900 text-white focus:outline-none focus-visible:ring focus-visible:ring-offset-2"
-        >
-          {t('pages.contact.submit')}
-        </button>
-      </form>
-    </section>
+    </Section>
   );
 }

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -10,7 +10,7 @@ export default function Hero() {
   return (
     <section
       aria-labelledby="hero-heading"
-      className="mx-auto max-w-6xl px-4 pt-16 pb-14 sm:pt-20 sm:pb-16"
+      className="not-prose mx-auto max-w-6xl px-4 pt-16 pb-14 sm:pt-20 sm:pb-16"
     >
       <div className="grid gap-8 lg:grid-cols-2 lg:items-center">
         {/* Text */}
@@ -36,7 +36,7 @@ export default function Hero() {
 
             <Link
               href="/contact"
-              className="inline-flex items-center justify-center rounded-2xl px-5 py-3 text-base font-medium bg-white text-gray-900 border border-gray-300 hover:bg-gray-50 focus:outline-none focus-visible:ring focus-visible:ring-offset-2"
+              className="inline-flex items-center justify-center rounded-2xl px-5 py-3 text-base font-medium border border-gray-300 bg-white text-gray-900 hover:bg-gray-50 focus:outline-none focus-visible:ring focus-visible:ring-offset-2"
               aria-label={t('hero.ctaSecondary')}
             >
               {t('hero.ctaSecondary')}

--- a/components/KycNotice.tsx
+++ b/components/KycNotice.tsx
@@ -21,7 +21,19 @@ export default function KycNotice({ locale, className = '', inline = false }: Pr
       }
     >
       {/* Без сторонних иконок — минималистично */}
-      <span aria-hidden="true">ℹ️ </span>
+      <span aria-hidden="true" className="inline-block align-[-2px]">
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          className="opacity-70"
+        >
+          <circle cx="12" cy="12" r="10" />
+          <rect x="11" y="10" width="2" height="7" fill="white" />
+          <rect x="11" y="7" width="2" height="2" fill="white" />
+        </svg>
+      </span>{' '}
       <span>{text}</span>
     </Wrapper>
   );

--- a/components/TopProductsTabs.tsx
+++ b/components/TopProductsTabs.tsx
@@ -20,7 +20,7 @@ export default function TopProductsTabs() {
   );
 
   return (
-    <Section aria-labelledby="top-products-heading" bg="white">
+    <Section aria-labelledby="top-products-heading" bg="white" containerClassName="not-prose">
       <div style={{ display: 'grid', gap: '1.5rem' }}>
         <h2 id="top-products-heading" style={{ fontSize: '2rem', fontWeight: 600, margin: 0 }}>
           {t('topProducts.title', 'Top Products by SoksLine')}

--- a/components/a11y/SkipLink.tsx
+++ b/components/a11y/SkipLink.tsx
@@ -4,7 +4,7 @@ export default function SkipLink() {
   return (
     <a
       href="#main-content"
-      className="sr-only focus:not-sr-only fixed top-2 left-2 z-50 rounded bg-gray-900 px-3 py-2 text-white"
+      className="sr-only focus-visible:not-sr-only fixed top-2 left-2 z-50 rounded bg-gray-900 px-3 py-2 text-white"
     >
       Skip to content
     </a>

--- a/components/legal/LegalPage.tsx
+++ b/components/legal/LegalPage.tsx
@@ -1,4 +1,5 @@
 'use client';
+import Section from '@/components/layout/Section';
 import LanguageSwitcher from '@/components/LanguageSwitcher';
 import Toc from './Toc';
 
@@ -8,43 +9,45 @@ type LegalDict = { title: string; disclaimer?: string; intro?: string; sections:
 export default function LegalPage({ dict }: { dict: LegalDict }) {
   const sections = dict.sections ?? [];
   return (
-    <main className="max-w-4xl mx-auto px-4 py-10">
-      <div className="flex items-center justify-between gap-4">
-        <h1 className="text-3xl font-semibold">{dict.title}</h1>
-        <LanguageSwitcher />
+    <Section bg="white" containerClassName="not-prose">
+      <div className="mx-auto flex max-w-5xl flex-col gap-6">
+        <div className="flex items-center justify-between gap-4">
+          <h1 className="text-3xl font-semibold">{dict.title}</h1>
+          <LanguageSwitcher />
+        </div>
+
+        {dict.disclaimer && (
+          <p className="rounded-xl border border-amber-200 bg-amber-50 p-3 text-sm text-amber-700">
+            {dict.disclaimer}
+          </p>
+        )}
+
+        {dict.intro && <p className="opacity-80">{dict.intro}</p>}
+
+        <div className="mt-6 grid gap-8 md:grid-cols-3">
+          <article className="prose max-w-none md:col-span-2">
+            {sections.map((s) => (
+              <section key={s.id} id={s.id} className="scroll-mt-24">
+                <h2 className="mt-8 mb-2 text-xl font-medium">{s.title}</h2>
+                {s.paragraphs?.map((p, i) => (
+                  <p key={i} className="opacity-90">
+                    {p}
+                  </p>
+                ))}
+                <div className="mt-4">
+                  <a href="#top" className="text-sm underline opacity-70">
+                    Back to top
+                  </a>
+                </div>
+              </section>
+            ))}
+          </article>
+
+          <aside className="md:col-span-1 md:sticky md:top-20 md:self-start" id="top">
+            <Toc items={sections.map(({ id, title }) => ({ id, title }))} />
+          </aside>
+        </div>
       </div>
-
-      {dict.disclaimer && (
-        <p className="mt-3 text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded-xl p-3">
-          {dict.disclaimer}
-        </p>
-      )}
-
-      {dict.intro && <p className="mt-4 opacity-80">{dict.intro}</p>}
-
-      <div className="mt-6 grid gap-8 md:grid-cols-[1fr_260px]">
-        <article className="prose max-w-none">
-          {sections.map((s) => (
-            <section key={s.id} id={s.id} className="scroll-mt-24">
-              <h2 className="text-xl font-medium mt-8 mb-2">{s.title}</h2>
-              {s.paragraphs?.map((p, i) => (
-                <p key={i} className="opacity-90">
-                  {p}
-                </p>
-              ))}
-              <div className="mt-4">
-                <a href="#top" className="text-sm underline opacity-70">
-                  Back to top
-                </a>
-              </div>
-            </section>
-          ))}
-        </article>
-
-        <aside className="md:sticky md:top-20 md:self-start" id="top">
-          <Toc items={sections.map(({ id, title }) => ({ id, title }))} />
-        </aside>
-      </div>
-    </main>
+    </Section>
   );
 }

--- a/components/ui/Tabs.tsx
+++ b/components/ui/Tabs.tsx
@@ -68,9 +68,11 @@ export default function Tabs({
               aria-selected={isSelected}
               aria-controls={panelId}
               tabIndex={isSelected ? 0 : -1} // roving tabindex
-              className={`px-4 py-2 rounded-2xl border transition 
-                 ${isSelected ? 'bg-gray-900 text-white border-gray-900' : 'bg-white border-gray-200 text-gray-700'} 
-                 focus:outline-none focus-visible:ring focus-visible:ring-offset-2`}
+              className={`px-4 py-2 rounded-2xl border transition ${
+                isSelected
+                  ? 'bg-gray-900 text-white border-gray-900'
+                  : 'bg-white border-gray-200 text-gray-700'
+              } focus:outline-none focus-visible:ring focus-visible:ring-offset-2`}
               onClick={() => select(i, false)}
               type="button"
             >


### PR DESCRIPTION
## Summary
- add `not-prose` wrappers and consistent CTA button styling on the hero and top products tabs
- hide the skip link until focused, tighten tab button states, and swap the KYC emoji for an inline SVG
- wrap the contact and legal pages in white sections with updated form and table-of-contents layouts

## Testing
- pnpm lint
- CI=1 pnpm build
- pnpm test:e2e *(fails: missing Playwright browser dependencies in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e133679878832aa7fa1b5c593aa30a