### PR TITLE
Hotfix: headings scale, card CTAs, button contrast, KYC align, section rhythm

### DIFF
--- a/app/page.module.css
+++ b/app/page.module.css
@@ -18,6 +18,7 @@
   font-size: clamp(1.75rem, 4vw, 2.6rem);
   font-weight: 700;
   color: #0b1b38;
+  letter-spacing: -0.02em;
 }
 
 .sectionDescription {
@@ -77,6 +78,7 @@
   font-size: 1.2rem;
   font-weight: 600;
   color: #0f172a;
+  line-height: 1.25;
 }
 
 .showcaseCardPrice {
@@ -136,6 +138,7 @@
   margin: 0;
   font-weight: 600;
   color: #111827;
+  line-height: 1.25;
 }
 
 .advantageText {
@@ -159,8 +162,7 @@
 
 .paymentsTitle {
   margin: 0;
-  font-size: clamp(1.75rem, 3.5vw, 2.4rem);
-  font-weight: 700;
+  color: #0b1b38;
 }
 
 .paymentsDescription {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import Hero from '@/components/Hero';
 import TopProductsTabs from '@/components/TopProductsTabs';
 import Section from '@/components/layout/Section';
@@ -8,12 +9,13 @@ import type { Locale } from '@/lib/i18n';
 import styles from './page.module.css';
 
 type Advantage = { title: string; description: string };
-type ShowcaseItem = { title: string; price: string; points: string[] };
+type ShowcaseItem = { title: string; price: string; points: string[]; ctaHref: string };
 
 type HomeContent = {
   showcase: {
     title: string;
     description: string;
+    learnMoreLabel: string;
     items: ShowcaseItem[];
     metrics: string[];
   };
@@ -35,21 +37,25 @@ const HOME_CONTENT: Record<Locale, HomeContent> = {
       title: 'Выберите формат прокси',
       description:
         'ISP-статика, IPv6 и ротация — фиксируйте нужные параметры, комбинируйте пулы и управляйте подключениями через единый кабинет.',
+      learnMoreLabel: 'Узнать больше →',
       items: [
         {
           title: 'Static ISP',
           price: 'от $5.90 / месяц',
           points: ['Дедикейт IPv4-подключения для долгих сессий', 'Выбор гео по городу и ASN'],
+          ctaHref: '/pricing#static-residential',
         },
         {
           title: 'Static ISP IPv6',
           price: 'от $3.40 / месяц',
           points: ['IPv6-пулы для масштабных задач', 'Лёгкая интеграция через SOCKS5'],
+          ctaHref: '/pricing/static-residential-ipv6#static-residential-ipv6',
         },
         {
           title: 'Rotating Residential',
           price: 'от $4.80 / GB',
           points: ['Автообновление IP по расписанию', 'Лимиты и сессии через API'],
+          ctaHref: '/pricing/rotating-residential#rotating-residential',
         },
       ],
       metrics: ['180+ Proxy Locations', '99.9% Uptime'],
@@ -88,21 +94,25 @@ const HOME_CONTENT: Record<Locale, HomeContent> = {
       title: 'Choose your proxy format',
       description:
         'Lock in ISP statics, IPv6, or rotation — mix pools, tune the parameters, and manage every connection from a single dashboard.',
+      learnMoreLabel: 'Learn more →',
       items: [
         {
           title: 'Static ISP',
           price: 'from $5.90 / month',
           points: ['Dedicated IPv4 access for long sessions', 'City- and ASN-level geo targeting'],
+          ctaHref: '/pricing#static-residential',
         },
         {
           title: 'Static ISP IPv6',
           price: 'from $3.40 / month',
           points: ['IPv6 pools for large-scale tasks', 'Easy SOCKS5 integration'],
+          ctaHref: '/pricing/static-residential-ipv6#static-residential-ipv6',
         },
         {
           title: 'Rotating Residential',
           price: 'from $4.80 / GB',
           points: ['Scheduled IP refresh', 'API-controlled limits and sessions'],
+          ctaHref: '/pricing/rotating-residential#rotating-residential',
         },
       ],
       metrics: ['180+ Proxy Locations', '99.9% Uptime'],
@@ -163,6 +173,12 @@ export default function Page() {
                   <li key={point}>{point}</li>
                 ))}
               </ul>
+              <Link
+                href={item.ctaHref}
+                className="inline-flex items-center gap-1 mt-3 text-blue-600 hover:underline"
+              >
+                {copy.showcase.learnMoreLabel}
+              </Link>
             </article>
           ))}
         </div>
@@ -190,12 +206,18 @@ export default function Page() {
 
       <TopProductsTabs />
 
-      <Section id="payments" bg="muted" containerClassName={styles.paymentsSection}>
+      <Section
+        id="payments"
+        bg="muted"
+        containerClassName={`${styles.paymentsSection} pt-6`}
+      >
         <div className={styles.paymentsHeader}>
-          <h2 className={styles.paymentsTitle}>{copy.payments.title}</h2>
+          <h2 className={`${styles.paymentsTitle} text-2xl sm:text-3xl font-semibold tracking-tight`}>
+            {copy.payments.title}
+          </h2>
           <p className={styles.paymentsDescription}>{copy.payments.description}</p>
         </div>
-        <div className={styles.paymentsList}>
+        <div className={`${styles.paymentsList} mt-4`}>
           {copy.payments.methods.map((method) => (
             <span key={method} className={styles.paymentBadge}>
               {method}

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -25,22 +25,22 @@ export default function Hero() {
           <div className="mt-4 text-sm text-gray-600">{t('hero.badge')}</div>
 
           {/* CTAs */}
-          <div className="mt-8 flex flex-wrap items-center gap-3">
-            <Link
-              href="/pricing"
-              className="inline-flex items-center justify-center rounded-2xl px-5 py-3 text-base font-medium bg-gray-900 text-white hover:bg-black focus:outline-none focus-visible:ring focus-visible:ring-offset-2"
-              aria-label={t('hero.ctaPrimary')}
-            >
-              {t('hero.ctaPrimary')}
-            </Link>
+        <div className="mt-8 flex flex-wrap items-center gap-3">
+          <Link
+            href="/pricing"
+            className="inline-flex items-center justify-center rounded-2xl px-5 py-3 text-base font-medium bg-gray-900 text-white hover:bg-black focus:outline-none focus-visible:ring focus-visible:ring-offset-2"
+            aria-label={t('hero.ctaPrimary')}
+          >
+            {t('hero.ctaPrimary')}
+          </Link>
 
-            <Link
-              href="/contact"
-              className="inline-flex items-center justify-center rounded-2xl px-5 py-3 text-base font-medium border border-gray-300 bg-white text-gray-900 hover:bg-gray-50 focus:outline-none focus-visible:ring focus-visible:ring-offset-2"
-              aria-label={t('hero.ctaSecondary')}
-            >
-              {t('hero.ctaSecondary')}
-            </Link>
+          <Link
+            href="/contact"
+            className="inline-flex w-full items-center justify-center rounded-2xl border border-gray-400 bg-white px-5 py-3 text-base font-medium text-gray-900 hover:bg-gray-50 focus:outline-none focus-visible:ring focus-visible:ring-offset-2 sm:w-auto"
+            aria-label={t('hero.ctaSecondary')}
+          >
+            {t('hero.ctaSecondary')}
+          </Link>
           </div>
         </div>
 

--- a/components/KycNotice.tsx
+++ b/components/KycNotice.tsx
@@ -21,13 +21,12 @@ export default function KycNotice({ locale, className = '', inline = false }: Pr
       }
     >
       {/* Без сторонних иконок — минималистично */}
-      <span aria-hidden="true" className="inline-block align-[-2px]">
+      <span aria-hidden="true" className="inline-block align-[-2px] opacity-60">
         <svg
           width="14"
           height="14"
           viewBox="0 0 24 24"
           fill="currentColor"
-          className="opacity-70"
         >
           <circle cx="12" cy="12" r="10" />
           <rect x="11" y="10" width="2" height="7" fill="white" />

--- a/components/PricingTemplate.tsx
+++ b/components/PricingTemplate.tsx
@@ -65,7 +65,7 @@ export default function PricingTemplate({ data }: PricingTemplateProps) {
   };
 
   return (
-    <div className={styles.page}>
+    <div id={copy.slug} className={styles.page}>
       <section className={styles.hero}>
         <div className={styles.heroInner}>
           <p className={styles.heroHighlight}>{copy.highlight}</p>

--- a/components/TopProductsTabs.tsx
+++ b/components/TopProductsTabs.tsx
@@ -22,7 +22,11 @@ export default function TopProductsTabs() {
   return (
     <Section aria-labelledby="top-products-heading" bg="white" containerClassName="not-prose">
       <div style={{ display: 'grid', gap: '1.5rem' }}>
-        <h2 id="top-products-heading" style={{ fontSize: '2rem', fontWeight: 600, margin: 0 }}>
+        <h2
+          id="top-products-heading"
+          className="text-3xl font-semibold tracking-tight text-slate-900"
+          style={{ margin: 0 }}
+        >
           {t('topProducts.title', 'Top Products by SoksLine')}
         </h2>
 

--- a/components/products/CategoryPanel.module.css
+++ b/components/products/CategoryPanel.module.css
@@ -36,6 +36,7 @@
   font-size: 1.05rem;
   font-weight: 600;
   color: #111827;
+  line-height: 1.25;
 }
 
 .cardPrice {


### PR DESCRIPTION
## Summary
- add localized "Learn more" CTAs with pricing anchors to the home showcase cards and tighten section spacing/typography, including the Payment methods heading
- tweak hero secondary CTA contrast/responsiveness and align KYC notice icon opacity with the spec
- expose pricing section anchors, update Top Products heading tracking, and tighten card title leading across shared components

## Testing
- pnpm lint
- pnpm build
- pnpm test:e2e *(fails: Playwright browsers not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e14a900750832a9bb857f3051b0329