### PR TITLE
Sync pricing page with order catalog data

### DIFF
--- a/app/pricing/page.module.css
+++ b/app/pricing/page.module.css
@@ -1,0 +1,293 @@
+.page {
+  background-color: #0b1220;
+}
+
+.hero {
+  padding: 4rem 1rem 3rem;
+  background: radial-gradient(120% 120% at 50% 0%, #1f2937 0%, #0b1220 70%);
+  color: #f9fafb;
+}
+
+.heroInner {
+  margin: 0 auto;
+  max-width: 56rem;
+  text-align: center;
+}
+
+.heroEyebrow {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  font-size: 0.875rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.heroTitle {
+  margin-top: 1rem;
+  font-size: clamp(2rem, 5vw, 3.25rem);
+  font-weight: 700;
+  line-height: 1.1;
+}
+
+.heroSubtitle {
+  margin-top: 1rem;
+  font-size: 1.125rem;
+  line-height: 1.6;
+  color: rgba(249, 250, 251, 0.84);
+}
+
+.heroDescription {
+  margin-top: 1.75rem;
+  font-size: 1rem;
+  line-height: 1.6;
+  color: rgba(249, 250, 251, 0.7);
+}
+
+.sectionHeader {
+  margin-bottom: 2rem;
+  max-width: 40rem;
+}
+
+.sectionTitle {
+  font-size: clamp(1.75rem, 4vw, 2.5rem);
+  font-weight: 700;
+  color: #0b1220;
+}
+
+.sectionSubtitle {
+  margin-top: 0.75rem;
+  font-size: 1.125rem;
+  color: rgba(11, 18, 32, 0.7);
+}
+
+.planGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+  gap: 1.5rem;
+}
+
+.planCard {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 2rem;
+  background: #ffffff;
+  border-radius: 1.25rem;
+  box-shadow: 0 18px 42px rgba(15, 23, 42, 0.08);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.planHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.planTitle {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #0b1220;
+}
+
+.planBadge {
+  align-self: flex-start;
+  margin-top: 0.5rem;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  background: #0b1220;
+  color: #f9fafb;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.planPrice {
+  margin-top: 1.5rem;
+  font-size: 2rem;
+  font-weight: 700;
+  color: #0b1220;
+}
+
+.planUnit {
+  display: block;
+  margin-top: 0.5rem;
+  font-size: 0.95rem;
+  color: rgba(11, 18, 32, 0.6);
+}
+
+.planFeatures {
+  margin: 1.5rem 0 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.75rem;
+  font-size: 0.95rem;
+  color: rgba(11, 18, 32, 0.76);
+}
+
+.planFooter {
+  margin-top: auto;
+}
+
+.planCta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  background: #0b1220;
+  color: #f9fafb;
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.planCta:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.2);
+}
+
+.ipv6Card {
+  background: #0b1220;
+  color: #f9fafb;
+  border-radius: 1.5rem;
+  padding: 2.5rem;
+  display: grid;
+  gap: 1.5rem;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.35);
+}
+
+.ipv6Price {
+  font-size: 1.75rem;
+  font-weight: 700;
+}
+
+.ipv6Features {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+  font-size: 1rem;
+}
+
+.ipv6Cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  background: #f9fafb;
+  color: #0b1220;
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.ipv6Cta:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(249, 250, 251, 0.35);
+}
+
+.rotatingGrid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.rotatingCard {
+  padding: 1.75rem 2rem;
+  background: #ffffff;
+  border-radius: 1.25rem;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 18px 42px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.rotatingTitle {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #0b1220;
+}
+
+.rotatingPrice {
+  font-size: 1.1rem;
+  color: rgba(11, 18, 32, 0.72);
+}
+
+.rotatingCta {
+  margin-top: 0.75rem;
+  align-self: flex-start;
+  display: inline-flex;
+  padding: 0.65rem 1.5rem;
+  border-radius: 999px;
+  background: #0b1220;
+  color: #f9fafb;
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.rotatingCta:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.2);
+}
+
+.kycWrapper {
+  margin-top: 2.5rem;
+}
+
+.paymentsCard {
+  margin-top: 2rem;
+  padding: 2rem;
+  border-radius: 1.25rem;
+  background: rgba(15, 23, 42, 0.03);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  display: grid;
+  gap: 1rem;
+}
+
+.paymentTitle {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: #0b1220;
+}
+
+.paymentNote {
+  color: rgba(11, 18, 32, 0.72);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.paymentMethods {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.paymentChip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  background: #ffffff;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #0b1220;
+}
+
+@media (max-width: 640px) {
+  .planCard,
+  .rotatingCard {
+    padding: 1.75rem;
+  }
+}

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -1,6 +1,225 @@
-import PricingTemplate from '@/components/PricingTemplate';
-import { STATIC_RESIDENTIAL_PRICING } from '@/lib/pricing';
+'use client';
+
+import Link from 'next/link';
+import { useMemo } from 'react';
+
+import { buildOrderUrl, catalog, type PlanId } from '@/config/catalog';
+import KycNotice from '@/components/KycNotice';
+import Section from '@/components/layout/Section';
+import { useI18n, type Locale } from '@/lib/i18n';
+import { getOrderPage, type OrderService } from '@/lib/order';
+
+import styles from './page.module.css';
+
+function formatUsd(value: number, locale: Locale) {
+  const formatter = new Intl.NumberFormat(locale === 'ru' ? 'ru-RU' : 'en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+  return formatter.format(value);
+}
+
+type PlanLocaleCopy = {
+  features: string[];
+  period?: string;
+  badge?: string;
+};
+
+function extractPlanCopy(service: OrderService | undefined) {
+  const copy = new Map<PlanId, PlanLocaleCopy>();
+  if (!service) {
+    return copy;
+  }
+
+  const tiers = service.categories.flatMap((category) => category.tiers);
+  for (const plan of catalog.staticIsp.plans) {
+    const match = tiers.find((tier) => tier.name === plan.title);
+    if (!match) continue;
+    copy.set(plan.id, {
+      features: match.features,
+      period: match.period,
+      badge: match.headline,
+    });
+  }
+  return copy;
+}
 
 export default function PricingPage() {
-  return <PricingTemplate data={STATIC_RESIDENTIAL_PRICING} />;
+  const { t, locale } = useI18n();
+  const orderPage = useMemo(() => getOrderPage(locale), [locale]);
+
+  const staticService = useMemo(
+    () => orderPage.services.find((service) => service.id === 'static-residential'),
+    [orderPage],
+  );
+  const staticPlanCopy = useMemo(() => extractPlanCopy(staticService), [staticService]);
+
+  const ipv6Service = useMemo(
+    () => orderPage.services.find((service) => service.id === 'static-residential-ipv6'),
+    [orderPage],
+  );
+  const rotatingService = useMemo(
+    () => orderPage.services.find((service) => service.id === 'rotating-residential'),
+    [orderPage],
+  );
+
+  const buyNowLabel = locale === 'ru' ? 'Купить' : t('common.buyNow', 'Buy Now');
+  const ipv6PriceLabel = ipv6Service?.card.priceHint ?? t('pages.pricing.staticIpv6.from', 'from $0.55 / mo');
+  const ipv6Highlights = ipv6Service?.card.highlights ?? [];
+
+  return (
+    <div className={styles.page}>
+      <header className={styles.hero}>
+        <div className={styles.heroInner}>
+          <span className={styles.heroEyebrow}>{t('pages.pricing.hero.eyebrow', 'Pricing')}</span>
+          <h1 className={styles.heroTitle}>{t('pages.pricing.hero.title', catalog.staticIsp.name)}</h1>
+          <p className={styles.heroSubtitle}>
+            {t(
+              'pages.pricing.hero.subtitle',
+              'Mirror of the latest plans available in the order flow.',
+            )}
+          </p>
+          <p className={styles.heroDescription}>
+            {t(
+              'pages.pricing.hero.description',
+              'Compare static and rotating residential proxy products with synced pricing and CTAs.',
+            )}
+          </p>
+        </div>
+      </header>
+
+      <Section id="static-isp" bg="white">
+        <div className={styles.sectionHeader}>
+          <h2 className={styles.sectionTitle}>
+            {t('pages.pricing.staticIsp.title', catalog.staticIsp.name)}
+          </h2>
+          <p className={styles.sectionSubtitle}>
+            {t(
+              'pages.pricing.staticIsp.subtitle',
+              staticService?.card.headline ?? catalog.staticIsp.summary ?? '',
+            )}
+          </p>
+        </div>
+
+        <div className={styles.planGrid}>
+          {catalog.staticIsp.plans.map((plan) => {
+            const localized = staticPlanCopy.get(plan.id);
+            const unitLabel = localized?.period ?? plan.unit;
+            const features = localized?.features ?? plan.features;
+            const badge = localized?.badge ?? plan.badge;
+
+            return (
+              <article key={plan.id} className={styles.planCard}>
+                <div className={styles.planHeader}>
+                  <h3 className={styles.planTitle}>{plan.title}</h3>
+                  {badge ? <span className={styles.planBadge}>{badge}</span> : null}
+                </div>
+                <p className={styles.planPrice}>
+                  {formatUsd(plan.priceUsd, locale)}
+                  <span className={styles.planUnit}>{unitLabel}</span>
+                </p>
+                <ul className={styles.planFeatures}>
+                  {features.map((feature) => (
+                    <li key={feature}>{feature}</li>
+                  ))}
+                </ul>
+                <div className={styles.planFooter}>
+                  <Link
+                    href={buildOrderUrl({ service: 'static-isp', plan: plan.id })}
+                    className={styles.planCta}
+                  >
+                    {buyNowLabel}
+                  </Link>
+                </div>
+              </article>
+            );
+          })}
+        </div>
+
+        <div className={styles.kycWrapper}>
+          <KycNotice />
+        </div>
+
+        <div className={styles.paymentsCard}>
+          <h3 className={styles.paymentTitle}>{orderPage.copy.paymentTitle}</h3>
+          <p className={styles.paymentNote}>{orderPage.paymentNote}</p>
+          <div className={styles.paymentMethods} aria-label={orderPage.copy.paymentMethodsLabel}>
+            {orderPage.paymentMethods.map((method) => (
+              <span key={method} className={styles.paymentChip}>
+                {method}
+              </span>
+            ))}
+          </div>
+        </div>
+      </Section>
+
+      <Section id="static-ipv6" bg="muted">
+        <div className={styles.sectionHeader}>
+          <h2 className={styles.sectionTitle}>
+            {t('pages.pricing.staticIpv6.title', catalog.staticIpv6.name)}
+          </h2>
+          <p className={styles.sectionSubtitle}>
+            {t(
+              'pages.pricing.staticIpv6.subtitle',
+              ipv6Service?.card.headline ?? catalog.staticIpv6.summary ?? '',
+            )}
+          </p>
+        </div>
+
+        <div className={styles.ipv6Card}>
+          <div>
+            <div className={styles.ipv6Price}>{ipv6PriceLabel}</div>
+            <ul className={styles.ipv6Features}>
+              {ipv6Highlights.map((feature) => (
+                <li key={feature}>{feature}</li>
+              ))}
+            </ul>
+          </div>
+          <Link
+            href={buildOrderUrl({ service: 'static-ipv6', duration: 'monthly' })}
+            className={styles.ipv6Cta}
+          >
+            {buyNowLabel}
+          </Link>
+        </div>
+      </Section>
+
+      <Section id="rotating" bg="white">
+        <div className={styles.sectionHeader}>
+          <h2 className={styles.sectionTitle}>
+            {t('pages.pricing.rotating.title', catalog.rotating.name)}
+          </h2>
+          <p className={styles.sectionSubtitle}>
+            {t(
+              'pages.pricing.rotating.subtitle',
+              rotatingService?.card.headline ?? '',
+            )}
+          </p>
+        </div>
+
+        <div className={styles.rotatingGrid}>
+          {catalog.rotating.tiers.map((tier) => {
+            const pricePerGb = tier.pricePerGbUsd ?? 0;
+            const totalUsd = tier.totalUsd ?? pricePerGb * tier.gb;
+            return (
+              <article key={tier.id} className={styles.rotatingCard}>
+                <div className={styles.rotatingTitle}>{`${tier.gb} GB`}</div>
+                <div className={styles.rotatingPrice}>
+                  {`${formatUsd(pricePerGb, locale)} / GB (Total ${formatUsd(totalUsd, locale)})`}
+                </div>
+                <Link
+                  href={buildOrderUrl({ service: 'rotating', duration: 'monthly' })}
+                  className={styles.rotatingCta}
+                >
+                  {buyNowLabel}
+                </Link>
+              </article>
+            );
+          })}
+        </div>
+      </Section>
+    </div>
+  );
 }

--- a/config/catalog.ts
+++ b/config/catalog.ts
@@ -124,14 +124,8 @@ export function buildOrderUrl(params: {
   plan?: PlanId;
   duration?: 'monthly' | 'yearly';
 }) {
-  const serviceMap: Record<ServiceId, string> = {
-    'static-isp': 'static-isp',
-    'static-ipv6': 'static-residential-ipv6',
-    rotating: 'rotating-residential',
-  };
-
   const q = new URLSearchParams({
-    service: serviceMap[params.service],
+    service: params.service,
     ...(params.plan ? { plan: params.plan } : {}),
     ...(params.duration ? { duration: params.duration } : { duration: 'monthly' }),
   });

--- a/config/catalog.ts
+++ b/config/catalog.ts
@@ -1,0 +1,139 @@
+import { getOrderPage } from '@/lib/order';
+import { rotatingPricing } from './pricing';
+
+export type ServiceId = 'static-isp' | 'static-ipv6' | 'rotating';
+export type PlanId = 'basic' | 'dedicated' | 'premium';
+
+export type Plan = {
+  id: PlanId;
+  title: string;
+  priceUsd: number;
+  unit: 'per proxy / mo';
+  features: string[];
+  badge?: string;
+};
+
+export type StaticCatalog = {
+  id: 'static-isp' | 'static-ipv6';
+  name: string;
+  summary?: string;
+  plans: Plan[];
+  fromUsd?: number;
+};
+
+export type RotatingTier = {
+  id: string;
+  gb: number;
+  pricePerGbUsd?: number;
+  totalUsd?: number;
+  badge?: string;
+};
+
+export type RotatingCatalog = {
+  id: 'rotating';
+  name: string;
+  tiers: RotatingTier[];
+};
+
+export type Catalog = {
+  staticIsp: StaticCatalog;
+  staticIpv6: StaticCatalog;
+  rotating: RotatingCatalog;
+};
+
+const ORDER_STATIC_PLAN_IDS: Record<PlanId, string> = {
+  basic: 'static-basic',
+  dedicated: 'static-dedicated',
+  premium: 'static-premium',
+};
+
+function parseUsdFromText(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const match = value.match(/\d+[\d,.]*/);
+  if (!match) return undefined;
+  const normalized = match[0].replace(/,/g, '');
+  const amount = Number.parseFloat(normalized);
+  return Number.isFinite(amount) ? amount : undefined;
+}
+
+const orderPage = getOrderPage('en');
+
+const staticService = orderPage.services.find((service) => service.id === 'static-residential');
+const staticPlanById = new Map(
+  (staticService?.categories ?? [])
+    .flatMap((category) => category.tiers)
+    .map((tier) => [tier.id, tier]),
+);
+
+const staticPlans: Plan[] = Object.entries(ORDER_STATIC_PLAN_IDS)
+  .map(([planId, orderTierId]) => {
+    const tier = staticPlanById.get(orderTierId);
+    if (!tier) return undefined;
+    return {
+      id: planId as PlanId,
+      title: tier.name,
+      priceUsd: tier.priceAmount,
+      unit: 'per proxy / mo',
+      features: tier.features,
+      badge: tier.headline,
+    } satisfies Plan;
+  })
+  .filter(Boolean) as Plan[];
+
+const ipv6Service = orderPage.services.find(
+  (service) => service.id === 'static-residential-ipv6',
+);
+
+const rotatingService = orderPage.services.find((service) => service.id === 'rotating-residential');
+
+const rotatingTiers: RotatingTier[] = rotatingPricing.tiers.map((tier) => {
+  const totalUsd = tier.totalUsd;
+  const pricePerGbUsd = tier.pricePerGbUsd ?? (tier.gb ? (totalUsd ?? 0) / tier.gb : undefined);
+  return {
+    id: tier.id,
+    gb: tier.gb,
+    totalUsd,
+    pricePerGbUsd,
+    badge: tier.badge,
+  } satisfies RotatingTier;
+});
+
+export const catalog: Catalog = {
+  staticIsp: {
+    id: 'static-isp',
+    name: staticService?.card.title ?? 'Static Residential Proxy',
+    summary: staticService?.card.headline,
+    plans: staticPlans,
+  },
+  staticIpv6: {
+    id: 'static-ipv6',
+    name: ipv6Service?.card.title ?? 'Static Residential IPv6',
+    summary: ipv6Service?.card.headline,
+    plans: [],
+    fromUsd: parseUsdFromText(ipv6Service?.card.priceHint),
+  },
+  rotating: {
+    id: 'rotating',
+    name: rotatingService?.card.title ?? 'Rotating Residential Proxy',
+    tiers: rotatingTiers,
+  },
+};
+
+export function buildOrderUrl(params: {
+  service: ServiceId;
+  plan?: PlanId;
+  duration?: 'monthly' | 'yearly';
+}) {
+  const serviceMap: Record<ServiceId, string> = {
+    'static-isp': 'static-isp',
+    'static-ipv6': 'static-residential-ipv6',
+    rotating: 'rotating-residential',
+  };
+
+  const q = new URLSearchParams({
+    service: serviceMap[params.service],
+    ...(params.plan ? { plan: params.plan } : {}),
+    ...(params.duration ? { duration: params.duration } : { duration: 'monthly' }),
+  });
+  return `/order?${q.toString()}`;
+}

--- a/locales/en.json
+++ b/locales/en.json
@@ -17,6 +17,9 @@
     "ctaPrimary": "Buy now",
     "ctaSecondary": "Contact sales"
   },
+  "common": {
+    "buyNow": "Buy Now"
+  },
   "tabs": {
     "staticIsp": "Static Residential (ISP)",
     "staticIpv6": "Static Residential (ISP) IPv6",
@@ -30,6 +33,27 @@
     "support": "Support"
   },
   "pages": {
+    "pricing": {
+      "hero": {
+        "eyebrow": "Pricing",
+        "title": "Residential proxy pricing synced with checkout",
+        "subtitle": "Browse the same products and plans available on the order page.",
+        "description": "Pick a static or rotating pool and deep-link straight to checkout with pricing that stays in sync."
+      },
+      "staticIsp": {
+        "title": "Static Residential Proxy",
+        "subtitle": "Dedicated IPv4 pools with sticky sessions and ISP-level targeting."
+      },
+      "staticIpv6": {
+        "title": "Static Residential IPv6",
+        "subtitle": "Scale automation with flexible IPv6 addresses and granular controls.",
+        "from": "from $0.55 / mo"
+      },
+      "rotating": {
+        "title": "Rotating Residential Proxy",
+        "subtitle": "Transparent bandwidth tiers with pay-as-you-go pricing."
+      }
+    },
     "aml": {
       "title": "AML Policy",
       "disclaimer": "Template content for product staging. This is not legal advice.",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -17,6 +17,9 @@
     "ctaPrimary": "Купить",
     "ctaSecondary": "Связаться"
   },
+  "common": {
+    "buyNow": "Купить"
+  },
   "tabs": {
     "staticIsp": "Static Residential (ISP)",
     "staticIpv6": "Static Residential (ISP) IPv6",
@@ -30,6 +33,27 @@
     "support": "Поддержка"
   },
   "pages": {
+    "pricing": {
+      "hero": {
+        "eyebrow": "Тарифы",
+        "title": "Цены на прокси синхронизированы с оформлением",
+        "subtitle": "Те же продукты и планы, что и на странице заказа.",
+        "description": "Выберите статический или ротационный пул и переходите к оформлению с актуальными ценами."
+      },
+      "staticIsp": {
+        "title": "Static Residential Proxy",
+        "subtitle": "Чистые IPv4 с sticky-сессиями и таргетингом по ISP."
+      },
+      "staticIpv6": {
+        "title": "Static Residential IPv6",
+        "subtitle": "Масштабируйте автоматизацию с гибкими IPv6 и управлением гео.",
+        "from": "от $0.55 / мес"
+      },
+      "rotating": {
+        "title": "Rotating Residential Proxy",
+        "subtitle": "Прозрачные тарифы по трафику и оплате за ГБ."
+      }
+    },
     "aml": {
       "title": "AML Политика",
       "disclaimer": "Шаблон для продукта (стейджинг). Не является юридической консультацией.",

--- a/tests/pricing-sync.spec.ts
+++ b/tests/pricing-sync.spec.ts
@@ -4,9 +4,9 @@ test('pricing shows Static ISP plans Basic/Dedicated/Premium with correct prices
   await page.goto('/pricing');
   const section = page.locator('#static-isp').first();
 
-  await expect(section.getByText('Basic')).toBeVisible();
-  await expect(section.getByText('Dedicated')).toBeVisible();
-  await expect(section.getByText('Premium')).toBeVisible();
+  await expect(section.getByRole('heading', { name: 'Basic' })).toBeVisible();
+  await expect(section.getByRole('heading', { name: 'Dedicated' })).toBeVisible();
+  await expect(section.getByRole('heading', { name: 'Premium' })).toBeVisible();
 
   await expect(section.getByText('$1.95', { exact: false })).toBeVisible();
   await expect(section.getByText('$3.95', { exact: false })).toBeVisible();
@@ -26,5 +26,5 @@ test('ipv6 block shows "from $0.55 / mo" and links to order', async ({ page }) =
 
 test('rotating tiers render with $/GB + Total', async ({ page }) => {
   await page.goto('/pricing#rotating');
-  await expect(page.getByText('/ GB (Total $', { exact: false })).toBeVisible();
+  await expect(page.getByText('/ GB (Total $', { exact: false }).first()).toBeVisible();
 });

--- a/tests/pricing-sync.spec.ts
+++ b/tests/pricing-sync.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+
+test('pricing shows Static ISP plans Basic/Dedicated/Premium with correct prices and deep-links', async ({ page }) => {
+  await page.goto('/pricing');
+  const section = page.locator('#static-isp').first();
+
+  await expect(section.getByText('Basic')).toBeVisible();
+  await expect(section.getByText('Dedicated')).toBeVisible();
+  await expect(section.getByText('Premium')).toBeVisible();
+
+  await expect(section.getByText('$1.95', { exact: false })).toBeVisible();
+  await expect(section.getByText('$3.95', { exact: false })).toBeVisible();
+  await expect(section.getByText('$5.47', { exact: false })).toBeVisible();
+
+  await section.getByRole('link', { name: /Buy Now/i }).first().click();
+  await expect(page).toHaveURL(/\/order\?service=static-isp&plan=/);
+});
+
+test('ipv6 block shows "from $0.55 / mo" and links to order', async ({ page }) => {
+  await page.goto('/pricing');
+  const s = page.locator('#static-ipv6');
+  await expect(s.getByText('from $0.55', { exact: false })).toBeVisible();
+  await s.getByRole('link', { name: /Buy Now|Купить/ }).click();
+  await expect(page).toHaveURL(/\/order\?service=static-ipv6/);
+});
+
+test('rotating tiers render with $/GB + Total', async ({ page }) => {
+  await page.goto('/pricing#rotating');
+  await expect(page.getByText('/ GB (Total $', { exact: false })).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- add a shared catalog config derived from the order page definitions plus a helper to generate deep-link URLs
- rebuild `/pricing` to mirror the order products, reuse localized order copy, and refresh the layout/styles with matching translations
- add an e2e spec that asserts pricing cards, IPv6 CTA, and rotating tiers stay synced with order data

## Testing
- pnpm lint
- pnpm typecheck
- pnpm build *(fails: Cannot find module 'tailwindcss')*
- pnpm test:e2e *(fails: Cannot find module 'tailwindcss')*

------
https://chatgpt.com/codex/tasks/task_e_68e1523610dc832aaae03851374e0e34