### PR TITLE
Pricing: add IPv6 plan cards and move compliance block

### DIFF
--- a/app/pricing/page.module.css
+++ b/app/pricing/page.module.css
@@ -153,48 +153,6 @@
   box-shadow: 0 12px 24px rgba(15, 23, 42, 0.2);
 }
 
-.ipv6Card {
-  background: #0b1220;
-  color: #f9fafb;
-  border-radius: 1.5rem;
-  padding: 2.5rem;
-  display: grid;
-  gap: 1.5rem;
-  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.35);
-}
-
-.ipv6Price {
-  font-size: 1.75rem;
-  font-weight: 700;
-}
-
-.ipv6Features {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
-  gap: 0.75rem;
-  font-size: 1rem;
-}
-
-.ipv6Cta {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.75rem 1.5rem;
-  border-radius: 999px;
-  background: #f9fafb;
-  color: #0b1220;
-  font-weight: 600;
-  text-decoration: none;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.ipv6Cta:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 12px 24px rgba(249, 250, 251, 0.35);
-}
-
 .rotatingGrid {
   display: grid;
   gap: 1.5rem;
@@ -238,51 +196,6 @@
 .rotatingCta:hover {
   transform: translateY(-1px);
   box-shadow: 0 12px 24px rgba(15, 23, 42, 0.2);
-}
-
-.kycWrapper {
-  margin-top: 2.5rem;
-}
-
-.paymentsCard {
-  margin-top: 2rem;
-  padding: 2rem;
-  border-radius: 1.25rem;
-  background: rgba(15, 23, 42, 0.03);
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  display: grid;
-  gap: 1rem;
-}
-
-.paymentTitle {
-  font-size: 1.125rem;
-  font-weight: 600;
-  color: #0b1220;
-}
-
-.paymentNote {
-  color: rgba(11, 18, 32, 0.72);
-  font-size: 0.95rem;
-  line-height: 1.5;
-}
-
-.paymentMethods {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-}
-
-.paymentChip {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.35rem 0.9rem;
-  border-radius: 999px;
-  background: #ffffff;
-  border: 1px solid rgba(15, 23, 42, 0.12);
-  font-size: 0.85rem;
-  font-weight: 600;
-  color: #0b1220;
 }
 
 @media (max-width: 640px) {

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -232,7 +232,7 @@ export default function PricingPage() {
       </Section>
 
       <Section bg="white" className="pt-10">
-        <KycNotice className="text-left mb-6" />
+        <KycNotice dataTestId="pricing-kyc-notice" className="text-left mb-6" />
         <PaymentsSecurity
           title={orderPage.copy.paymentTitle}
           note={orderPage.paymentNote}

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -5,6 +5,7 @@ import { useMemo } from 'react';
 
 import { buildOrderUrl, catalog, type PlanId } from '@/config/catalog';
 import KycNotice from '@/components/KycNotice';
+import PaymentsSecurity from '@/components/PaymentsSecurity';
 import Section from '@/components/layout/Section';
 import { useI18n } from '@/lib/i18n';
 import { getOrderPage, type OrderService } from '@/lib/order';
@@ -12,7 +13,7 @@ import { getOrderPage, type OrderService } from '@/lib/order';
 import styles from './page.module.css';
 
 function formatUsd(value: number) {
-  return `$${value.toFixed(2)}`;
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(value);
 }
 
 type PlanLocaleCopy = {
@@ -60,26 +61,7 @@ export default function PricingPage() {
   );
 
   const buyNowLabel = locale === 'ru' ? 'Купить' : t('common.buyNow', 'Buy Now');
-  const ipv6PriceLabel = useMemo(() => {
-    const hint = ipv6Service?.card.priceHint?.trim();
-    if (hint) {
-      return hint;
-    }
-
-    const fromUsd = catalog.staticIpv6.fromUsd;
-    if (typeof fromUsd === 'number') {
-      const price = formatUsd(fromUsd);
-      const template = locale === 'ru'
-        ? t('pages.pricing.staticIpv6.from', 'от $0.55 / мес')
-        : t('pages.pricing.staticIpv6.from', 'from $0.55 / mo');
-      return template.replace('$0.55', price);
-    }
-
-    return locale === 'ru'
-      ? t('pages.pricing.staticIpv6.from', 'от $0.55 / мес')
-      : t('pages.pricing.staticIpv6.from', 'from $0.55 / mo');
-  }, [ipv6Service, locale, t]);
-  const ipv6Highlights = ipv6Service?.card.highlights ?? [];
+  const ipv6FallbackFromUsd = catalog.staticIpv6.fromUsd ?? 0.55;
 
   return (
     <div className={styles.page}>
@@ -102,9 +84,9 @@ export default function PricingPage() {
         </div>
       </header>
 
-      <Section bg="white">
+      <Section id="static-isp" bg="white" className="scroll-mt-28">
         <div className={styles.sectionHeader}>
-          <h2 id="static-isp" className={`${styles.sectionTitle} scroll-mt-28`}>
+          <h2 className={styles.sectionTitle}>
             {t('pages.pricing.staticIsp.title', catalog.staticIsp.name)}
           </h2>
           <p className={styles.sectionSubtitle}>
@@ -118,9 +100,11 @@ export default function PricingPage() {
         <div className={styles.planGrid}>
           {catalog.staticIsp.plans.map((plan) => {
             const localized = staticPlanCopy.get(plan.id);
-            const unitLabel = localized?.period ?? plan.unit;
+            const unitLabelSource = localized?.period ?? plan.unit ?? 'per proxy / mo';
+            const unitLabel = unitLabelSource.replace('month', 'mo');
             const features = localized?.features ?? plan.features;
             const badge = localized?.badge ?? plan.badge;
+            const priceValue = plan.priceUsd ?? catalog.staticIsp.fromUsd ?? 0;
 
             return (
               <article key={plan.id} className={styles.planCard}>
@@ -129,7 +113,7 @@ export default function PricingPage() {
                   {badge ? <span className={styles.planBadge}>{badge}</span> : null}
                 </div>
                 <p className={styles.planPrice}>
-                  {formatUsd(plan.priceUsd)}
+                  {formatUsd(priceValue)}
                   <span className={styles.planUnit}>{unitLabel}</span>
                 </p>
                 <ul className={styles.planFeatures}>
@@ -150,26 +134,11 @@ export default function PricingPage() {
           })}
         </div>
 
-        <div className={styles.kycWrapper}>
-          <KycNotice />
-        </div>
-
-        <div className={styles.paymentsCard}>
-          <h3 className={styles.paymentTitle}>{orderPage.copy.paymentTitle}</h3>
-          <p className={styles.paymentNote}>{orderPage.paymentNote}</p>
-          <div className={styles.paymentMethods} aria-label={orderPage.copy.paymentMethodsLabel}>
-            {orderPage.paymentMethods.map((method) => (
-              <span key={method} className={styles.paymentChip}>
-                {method}
-              </span>
-            ))}
-          </div>
-        </div>
       </Section>
 
-      <Section bg="muted">
+      <Section id="static-ipv6" bg="muted" className="scroll-mt-28">
         <div className={styles.sectionHeader}>
-          <h2 id="static-ipv6" className={`${styles.sectionTitle} scroll-mt-28`}>
+          <h2 className={styles.sectionTitle}>
             {t('pages.pricing.staticIpv6.title', catalog.staticIpv6.name)}
           </h2>
           <p className={styles.sectionSubtitle}>
@@ -180,27 +149,47 @@ export default function PricingPage() {
           </p>
         </div>
 
-        <div className={styles.ipv6Card}>
-          <div>
-            <div className={styles.ipv6Price}>{ipv6PriceLabel}</div>
-            <ul className={styles.ipv6Features}>
-              {ipv6Highlights.map((feature) => (
-                <li key={feature}>{feature}</li>
-              ))}
-            </ul>
-          </div>
-          <Link
-            href={buildOrderUrl({ service: 'static-ipv6', duration: 'monthly' })}
-            className={styles.ipv6Cta}
-          >
-            {buyNowLabel}
-          </Link>
+        <div className={styles.planGrid}>
+          {catalog.staticIpv6.plans.map((plan) => {
+            const hasPrice = typeof plan.priceUsd === 'number';
+            const priceLabel = hasPrice
+              ? formatUsd(plan.priceUsd ?? 0)
+              : `from ${formatUsd(ipv6FallbackFromUsd)}`;
+            const unitLabelSource = plan.unit ?? 'per proxy / mo';
+            const unitLabel = unitLabelSource.replace('month', 'mo');
+
+            return (
+              <article key={plan.id} className={styles.planCard}>
+                <div className={styles.planHeader}>
+                  <h3 className={styles.planTitle}>{plan.title}</h3>
+                  {plan.badge ? <span className={styles.planBadge}>{plan.badge}</span> : null}
+                </div>
+                <p className={styles.planPrice}>
+                  {priceLabel}
+                  <span className={styles.planUnit}>{unitLabel}</span>
+                </p>
+                <ul className={styles.planFeatures}>
+                  {plan.features.map((feature) => (
+                    <li key={feature}>{feature}</li>
+                  ))}
+                </ul>
+                <div className={styles.planFooter}>
+                  <Link
+                    href={buildOrderUrl({ service: 'static-ipv6', plan: plan.id, duration: 'monthly' })}
+                    className={styles.planCta}
+                  >
+                    {buyNowLabel}
+                  </Link>
+                </div>
+              </article>
+            );
+          })}
         </div>
       </Section>
 
-      <Section bg="white">
+      <Section id="rotating" bg="white" className="scroll-mt-28">
         <div className={styles.sectionHeader}>
-          <h2 id="rotating" className={`${styles.sectionTitle} scroll-mt-28`}>
+          <h2 className={styles.sectionTitle}>
             {t('pages.pricing.rotating.title', catalog.rotating.name)}
           </h2>
           <p className={styles.sectionSubtitle}>
@@ -240,6 +229,16 @@ export default function PricingPage() {
             );
           })}
         </div>
+      </Section>
+
+      <Section bg="white" className="pt-10">
+        <KycNotice className="text-left mb-6" />
+        <PaymentsSecurity
+          title={orderPage.copy.paymentTitle}
+          note={orderPage.paymentNote}
+          methods={orderPage.paymentMethods}
+          methodsAriaLabel={orderPage.copy.paymentMethodsLabel}
+        />
       </Section>
     </div>
   );

--- a/components/KycNotice.tsx
+++ b/components/KycNotice.tsx
@@ -14,8 +14,10 @@ export default function KycNotice({ locale, className = '', inline = false }: Pr
   const { t } = useI18n();
   const text = locale ? getKycPolicy(locale) : t('kyc.policy');
   const Wrapper: any = inline ? 'span' : 'div';
+  const dataTestId = inline ? undefined : 'kyc-notice';
   return (
     <Wrapper
+      data-testid={dataTestId}
       className={
         inline ? `text-sm opacity-80 ${className}` : `text-sm opacity-80 mt-2 ${className}`
       }

--- a/components/KycNotice.tsx
+++ b/components/KycNotice.tsx
@@ -8,16 +8,22 @@ type Props = {
   locale?: Locale; // 'en' | 'ru'; по умолчанию — 'en'
   className?: string; // для отступов/типографики
   inline?: boolean; // inline-версия внутри карточек
+  dataTestId?: string; // кастомный data-testid для e2e-тестов
 };
 
-export default function KycNotice({ locale, className = '', inline = false }: Props) {
+export default function KycNotice({
+  locale,
+  className = '',
+  inline = false,
+  dataTestId,
+}: Props) {
   const { t } = useI18n();
   const text = locale ? getKycPolicy(locale) : t('kyc.policy');
   const Wrapper: any = inline ? 'span' : 'div';
-  const dataTestId = inline ? undefined : 'kyc-notice';
+  const resolvedTestId = inline ? undefined : dataTestId;
   return (
     <Wrapper
-      data-testid={dataTestId}
+      data-testid={resolvedTestId}
       className={
         inline ? `text-sm opacity-80 ${className}` : `text-sm opacity-80 mt-2 ${className}`
       }

--- a/components/PaymentsSecurity.tsx
+++ b/components/PaymentsSecurity.tsx
@@ -1,0 +1,42 @@
+import clsx from 'clsx';
+
+interface PaymentsSecurityProps {
+  title: string;
+  note: string;
+  methods: string[];
+  methodsAriaLabel?: string;
+  className?: string;
+}
+
+export default function PaymentsSecurity({
+  title,
+  note,
+  methods,
+  methodsAriaLabel,
+  className = '',
+}: PaymentsSecurityProps) {
+  return (
+    <div
+      className={clsx(
+        'w-full rounded-2xl border border-gray-200 bg-white px-6 py-6 shadow-sm sm:px-8',
+        className,
+      )}
+    >
+      <h3 className="text-lg font-semibold text-gray-900">{title}</h3>
+      <p className="mt-2 text-sm text-gray-600">{note}</p>
+      <div
+        className="mt-4 flex flex-wrap gap-2"
+        aria-label={methodsAriaLabel ?? title}
+      >
+        {methods.map((method) => (
+          <span
+            key={method}
+            className="inline-flex items-center rounded-full bg-gray-50 px-3 py-1 text-sm font-medium text-gray-900 ring-1 ring-gray-200"
+          >
+            {method}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/PaymentsSecurity.tsx
+++ b/components/PaymentsSecurity.tsx
@@ -17,6 +17,7 @@ export default function PaymentsSecurity({
 }: PaymentsSecurityProps) {
   return (
     <div
+      data-testid="payments-security"
       className={clsx(
         'w-full rounded-2xl border border-gray-200 bg-white px-6 py-6 shadow-sm sm:px-8',
         className,

--- a/tests/pricing-kyc-bottom-ipv6-cards.spec.ts
+++ b/tests/pricing-kyc-bottom-ipv6-cards.spec.ts
@@ -15,8 +15,8 @@ test('IPv6 section renders 3 plan cards and deep-links to order', async ({ page 
 test('KYC & Payments appear once at the bottom, not under ISP', async ({ page }) => {
   await page.goto('/pricing');
   const ispSection = page.locator('#static-isp');
-  await expect(ispSection.getByTestId('kyc-notice')).toHaveCount(0);
+  await expect(ispSection.getByTestId('pricing-kyc-notice')).toHaveCount(0);
   await page.locator('footer').scrollIntoViewIfNeeded({ timeout: 5_000 }).catch(() => undefined);
-  await expect(page.getByTestId('kyc-notice')).toHaveCount(1);
+  await expect(page.getByTestId('pricing-kyc-notice')).toHaveCount(1);
   await expect(page.getByTestId('payments-security')).toBeVisible();
 });

--- a/tests/pricing-kyc-bottom-ipv6-cards.spec.ts
+++ b/tests/pricing-kyc-bottom-ipv6-cards.spec.ts
@@ -14,9 +14,25 @@ test('IPv6 section renders 3 plan cards and deep-links to order', async ({ page 
 
 test('KYC & Payments appear once at the bottom, not under ISP', async ({ page }) => {
   await page.goto('/pricing');
-  const ispSection = page.locator('#static-isp');
-  await expect(ispSection.getByTestId('pricing-kyc-notice')).toHaveCount(0);
-  await page.locator('footer').scrollIntoViewIfNeeded({ timeout: 5_000 }).catch(() => undefined);
+  const rotatingSection = page.locator('#rotating');
+  const footerNotice = page.getByTestId('pricing-kyc-notice').first();
+  const payments = page.getByTestId('payments-security').first();
+
   await expect(page.getByTestId('pricing-kyc-notice')).toHaveCount(1);
-  await expect(page.getByTestId('payments-security')).toBeVisible();
+  await expect(page.getByTestId('payments-security')).toHaveCount(1);
+
+  const [rotatingBox, noticeBox, paymentsBox] = await Promise.all([
+    rotatingSection.boundingBox(),
+    footerNotice.boundingBox(),
+    payments.boundingBox(),
+  ]);
+
+  expect(rotatingBox).toBeTruthy();
+  expect(noticeBox).toBeTruthy();
+  expect(paymentsBox).toBeTruthy();
+
+  if (!rotatingBox || !noticeBox || !paymentsBox) return;
+
+  expect(noticeBox.y).toBeGreaterThan(rotatingBox.y);
+  expect(paymentsBox.y).toBeGreaterThan(rotatingBox.y);
 });

--- a/tests/pricing-kyc-bottom-ipv6-cards.spec.ts
+++ b/tests/pricing-kyc-bottom-ipv6-cards.spec.ts
@@ -4,8 +4,12 @@ test('IPv6 section renders 3 plan cards and deep-links to order', async ({ page 
   await page.goto('/pricing#static-ipv6');
   const cards = page.locator('#static-ipv6 article');
   await expect(cards).toHaveCount(3);
-  await cards.nth(0).getByRole('link', { name: /Buy|Купить/i }).click();
-  await expect(page).toHaveURL(/\/order\?service=static-ipv6&plan=/);
+  const firstCta = cards.nth(0).getByRole('link', { name: /Buy|Купить/i });
+  const href = await firstCta.getAttribute('href');
+  expect(href).toBeTruthy();
+  expect(href).toContain('service=static-ipv6');
+  expect(href).toMatch(/plan=(basic|dedicated|premium)/);
+  expect(href).toContain('duration=monthly');
 });
 
 test('KYC & Payments appear once at the bottom, not under ISP', async ({ page }) => {
@@ -13,5 +17,5 @@ test('KYC & Payments appear once at the bottom, not under ISP', async ({ page })
   const ispSection = page.locator('#static-isp');
   await expect(ispSection.getByText(/KYC/i)).toHaveCount(0);
   await page.locator('footer').scrollIntoViewIfNeeded({ timeout: 5_000 }).catch(() => undefined);
-  await expect(page.getByText(/BTC|ETH|USDT/)).toBeVisible();
+  await expect(page.getByText('BTC', { exact: true })).toBeVisible();
 });

--- a/tests/pricing-kyc-bottom-ipv6-cards.spec.ts
+++ b/tests/pricing-kyc-bottom-ipv6-cards.spec.ts
@@ -15,7 +15,8 @@ test('IPv6 section renders 3 plan cards and deep-links to order', async ({ page 
 test('KYC & Payments appear once at the bottom, not under ISP', async ({ page }) => {
   await page.goto('/pricing');
   const ispSection = page.locator('#static-isp');
-  await expect(ispSection.getByText(/KYC/i)).toHaveCount(0);
+  await expect(ispSection.getByTestId('kyc-notice')).toHaveCount(0);
   await page.locator('footer').scrollIntoViewIfNeeded({ timeout: 5_000 }).catch(() => undefined);
-  await expect(page.getByText('BTC', { exact: true })).toBeVisible();
+  await expect(page.getByTestId('kyc-notice')).toHaveCount(1);
+  await expect(page.getByTestId('payments-security')).toBeVisible();
 });

--- a/tests/pricing-kyc-bottom-ipv6-cards.spec.ts
+++ b/tests/pricing-kyc-bottom-ipv6-cards.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test';
+
+test('IPv6 section renders 3 plan cards and deep-links to order', async ({ page }) => {
+  await page.goto('/pricing#static-ipv6');
+  const cards = page.locator('#static-ipv6 article');
+  await expect(cards).toHaveCount(3);
+  await cards.nth(0).getByRole('link', { name: /Buy|Купить/i }).click();
+  await expect(page).toHaveURL(/\/order\?service=static-ipv6&plan=/);
+});
+
+test('KYC & Payments appear once at the bottom, not under ISP', async ({ page }) => {
+  await page.goto('/pricing');
+  const ispSection = page.locator('#static-isp');
+  await expect(ispSection.getByText(/KYC/i)).toHaveCount(0);
+  await page.locator('footer').scrollIntoViewIfNeeded({ timeout: 5_000 }).catch(() => undefined);
+  await expect(page.getByText(/BTC|ETH|USDT/)).toBeVisible();
+});

--- a/tests/pricing-sync.spec.ts
+++ b/tests/pricing-sync.spec.ts
@@ -1,12 +1,10 @@
 import { test, expect } from '@playwright/test';
 
 test('pricing shows Static ISP plans Basic/Dedicated/Premium with correct prices and deep-links', async ({ page }) => {
-  await page.goto('/pricing');
-  const section = page
-    .locator('section')
-    .filter({ has: page.locator('#static-isp') })
-    .first();
+  await page.goto('/pricing#static-isp');
+  const section = page.locator('#static-isp');
 
+  await expect(section.locator('article')).toHaveCount(3);
   await expect(section.getByRole('heading', { name: 'Basic' })).toBeVisible();
   await expect(section.getByRole('heading', { name: 'Dedicated' })).toBeVisible();
   await expect(section.getByRole('heading', { name: 'Premium' })).toBeVisible();
@@ -15,19 +13,25 @@ test('pricing shows Static ISP plans Basic/Dedicated/Premium with correct prices
   await expect(section.getByText('$3.95', { exact: false })).toBeVisible();
   await expect(section.getByText('$5.47', { exact: false })).toBeVisible();
 
-  await section.getByRole('link', { name: /Buy Now/i }).first().click();
-  await expect(page).toHaveURL(/\/order\?service=static-isp&plan=/);
+  const firstCta = section.getByRole('link', { name: /Buy Now|Купить/ }).first();
+  await expect(firstCta).toHaveAttribute('href', /service=static-isp&plan=/);
 });
 
-test('ipv6 block shows "from $0.55 / mo" and links to order', async ({ page }) => {
-  await page.goto('/pricing');
-  const s = page
-    .locator('section')
-    .filter({ has: page.locator('#static-ipv6') })
-    .first();
-  await expect(s.getByText('from $0.55', { exact: false })).toBeVisible();
-  await s.getByRole('link', { name: /Buy Now|Купить/ }).click();
-  await expect(page).toHaveURL(/\/order\?service=static-ipv6/);
+test('ipv6 block shows Basic/Dedicated/Premium plan cards with pricing and order links', async ({ page }) => {
+  await page.goto('/pricing#static-ipv6');
+  const section = page.locator('#static-ipv6');
+
+  await expect(section.locator('article')).toHaveCount(3);
+  await expect(section.getByRole('heading', { name: 'Basic' })).toBeVisible();
+  await expect(section.getByRole('heading', { name: 'Dedicated' })).toBeVisible();
+  await expect(section.getByRole('heading', { name: 'Premium' })).toBeVisible();
+
+  const priceProbe = section.locator('article').first().getByText(/\$\d|from \$/);
+  await expect(priceProbe.first()).toBeVisible();
+
+  const ctas = section.getByRole('link', { name: /Buy Now|Купить/ });
+  await expect(ctas).toHaveCount(3);
+  await expect(ctas.first()).toHaveAttribute('href', /service=static-ipv6&plan=.+&duration=monthly/);
 });
 
 test('rotating tiers render with $/GB + Total', async ({ page }) => {


### PR DESCRIPTION
## Summary
- load Static IPv6 plan metadata from the shared catalog and render three plan cards with pricing fallbacks
- relocate the KYC notice and payment methods into a shared footer section with a reusable PaymentsSecurity component
- cover the new layout with a dedicated Playwright spec for IPv6 plans and the footer compliance block

## Testing
- pnpm lint
- pnpm test


------
https://chatgpt.com/codex/tasks/task_e_68e23a7670ec832a9d1b92f25e16db7c