### PR TITLE
Adjust Why SoksLine grid layout

### DIFF
--- a/app/page.module.css
+++ b/app/page.module.css
@@ -113,10 +113,7 @@
 }
 
 .advantagesGrid {
-  display: grid;
-  gap: clamp(1.1rem, 2vw, 1.6rem);
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  justify-content: center;
+  width: 100%;
 }
 
 .advantageCard {
@@ -124,8 +121,6 @@
   border-radius: 1.5rem;
   padding: clamp(1.1rem, 2.2vw, 1.6rem);
   box-shadow: 0 24px 48px -42px rgba(15, 23, 42, 0.65);
-  display: grid;
-  gap: 0.5rem;
   text-align: left;
 }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -194,9 +194,14 @@ export default function Page() {
           <h2 className={styles.sectionTitle}>{copy.advantages.title}</h2>
           <p className={styles.sectionDescription}>{copy.advantages.description}</p>
         </div>
-        <div className={styles.advantagesGrid}>
+        <div
+          className={`${styles.advantagesGrid} grid grid-cols-1 items-stretch gap-6 sm:grid-cols-2 lg:grid-cols-3`}
+        >
           {copy.advantages.items.map((item) => (
-            <article key={item.title} className={styles.advantageCard}>
+            <article
+              key={item.title}
+              className={`${styles.advantageCard} min-h-[140px] flex flex-col gap-3`}
+            >
               <h3 className={styles.advantageTitle}>{item.title}</h3>
               <p className={styles.advantageText}>{item.description}</p>
             </article>


### PR DESCRIPTION
## Summary
- apply the requested responsive grid configuration to the Why SoksLine section
- add consistent spacing and a minimum height so the advantage cards align on the baseline

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e25e29fb20832aae42d579b030a23e