### PR TITLE
Adjust back to top link placement on legal page

### DIFF
--- a/components/legal/LegalPage.tsx
+++ b/components/legal/LegalPage.tsx
@@ -34,13 +34,16 @@ export default function LegalPage({ dict }: { dict: LegalDict }) {
                     {p}
                   </p>
                 ))}
-                <div className="mt-4">
-                  <a href="#top" className="text-sm underline opacity-70">
-                    Back to top
-                  </a>
-                </div>
               </section>
             ))}
+
+            {sections.length > 0 && (
+              <div className="mt-8">
+                <a href="#top" className="text-sm underline opacity-70">
+                  Back to top
+                </a>
+              </div>
+            )}
           </article>
 
           <aside className="md:col-span-1 md:sticky md:top-20 md:self-start" id="top">


### PR DESCRIPTION
## Summary
- remove per-section Back to top links on the legal AML sections
- add a single Back to top link at the bottom of the legal content

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e279474478832aa1051e91d47f2145