### PR TITLE
feat: refresh order builder layout

### DIFF
--- a/components/icons/Check.tsx
+++ b/components/icons/Check.tsx
@@ -1,0 +1,5 @@
+export const Check = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" {...props}>
+    <path d="M7.8 13.4 4.7 10.3 3.3 11.7l4.5 4.5 9-9-1.4-1.4-7.6 7.6z" />
+  </svg>
+);

--- a/components/order/ProgressStepper.tsx
+++ b/components/order/ProgressStepper.tsx
@@ -1,0 +1,16 @@
+export default function ProgressStepper({ step = 2 }: { step?: 1 | 2 | 3 | 4 }) {
+  const items = ['Продукт', 'План', 'Настройки', 'Оплата'];
+  return (
+    <ol className="mt-2 flex items-center gap-3 text-sm text-gray-500" aria-label="Шаги оформления">
+      {items.map((title, index) => (
+        <li key={title} className="flex items-center gap-2">
+          <span
+            className={`h-2.5 w-2.5 rounded-full ${index + 1 <= step ? 'bg-gray-900' : 'bg-gray-300'}`}
+          />
+          <span className={index + 1 === step ? 'font-medium text-gray-900' : ''}>{title}</span>
+          {index < items.length - 1 && <span className="mx-1 text-gray-300">›</span>}
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/components/order/SummaryBarMobile.tsx
+++ b/components/order/SummaryBarMobile.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+type SummaryBarMobileProps = {
+  total: string;
+  totalLabel: string;
+  summary?: string;
+  ctaLabel: string;
+  onNext: () => void;
+};
+
+export default function SummaryBarMobile({ total, totalLabel, summary, ctaLabel, onNext }: SummaryBarMobileProps) {
+  return (
+    <div className="fixed inset-x-0 bottom-0 z-40 border-t border-gray-200 bg-white/95 backdrop-blur supports-[backdrop-filter]:backdrop-blur md:hidden">
+      <div className="mx-auto flex max-w-6xl items-center gap-3 px-4 py-3">
+        <div>
+          <div className="text-sm text-gray-600">{totalLabel}</div>
+          {summary ? <div className="text-xs text-gray-500">{summary}</div> : null}
+        </div>
+        <div className="ml-auto text-xl font-semibold text-gray-900 [font-variant-numeric:tabular-nums]">{total}</div>
+        <button
+          onClick={onNext}
+          className="ml-2 rounded-2xl bg-gray-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-black focus:outline-none focus-visible:ring focus-visible:ring-gray-900 focus-visible:ring-offset-2"
+        >
+          {ctaLabel}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/ui/StepperInput.tsx
+++ b/components/ui/StepperInput.tsx
@@ -1,0 +1,57 @@
+'use client';
+import { useId } from 'react';
+
+type Props = {
+  value: number;
+  min?: number;
+  max?: number;
+  step?: number;
+  onChange: (v: number) => void;
+  className?: string;
+  label?: string;
+};
+
+export default function StepperInput({
+  value,
+  min = 1,
+  max = 9999,
+  step = 1,
+  onChange,
+  className = '',
+  label,
+}: Props) {
+  const id = useId();
+  const clamp = (v: number) => Math.max(min, Math.min(max, v));
+  return (
+    <div className={className}>
+      {label && (
+        <label htmlFor={id} className="mb-1 block text-sm font-medium text-gray-700">
+          {label}
+        </label>
+      )}
+      <div className="flex overflow-hidden rounded-xl border border-gray-300 bg-white shadow-sm">
+        <button
+          type="button"
+          onClick={() => onChange(clamp(value - step))}
+          className="px-3 py-2 text-lg leading-none text-gray-700 transition hover:bg-gray-50 focus:outline-none focus-visible:ring focus-visible:ring-gray-900 focus-visible:ring-offset-2"
+        >
+          −
+        </button>
+        <input
+          id={id}
+          inputMode="numeric"
+          value={value}
+          onChange={(e) => onChange(clamp(Number.parseInt(e.target.value || '0', 10) || 0))}
+          className="w-full px-3 py-2 text-center text-base text-gray-900 outline-none [appearance:textfield] [font-variant-numeric:tabular-nums]"
+        />
+        <button
+          type="button"
+          onClick={() => onChange(clamp(value + step))}
+          className="px-3 py-2 text-lg leading-none text-gray-700 transition hover:bg-gray-50 focus:outline-none focus-visible:ring focus-visible:ring-gray-900 focus-visible:ring-offset-2"
+        >
+          +
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/lib/money.ts
+++ b/lib/money.ts
@@ -1,6 +1,16 @@
 export const fmtUSD = (n: number) =>
   new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(n);
 
+export function fmtUsdByLocale(locale: string, value: number) {
+  const nf = new Intl.NumberFormat(locale === 'ru' ? 'ru-RU' : 'en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 2,
+    minimumFractionDigits: 2,
+  });
+  return nf.format(value);
+}
+
 export function roundCents(n: number): number {
   return Math.round(n * 100) / 100;
 }

--- a/lib/order.ts
+++ b/lib/order.ts
@@ -91,13 +91,13 @@ const SERVICE_DEFINITIONS: ServiceDefinition[] = [
       ru: {
         title: 'Static Residential Proxy',
         headline: 'Скорость до 1 Гбит/с',
-        priceHint: 'от $1.27 / мес',
+        priceHint: 'от $1.27 /\u00a0мес',
         highlights: ['Надёжные IPv4', 'Sticky-сессии до 60 мин', 'Таргетинг по странам и ISP'],
       },
       en: {
         title: 'Static Residential Proxy',
         headline: 'Speeds up to 1 Gbps',
-        priceHint: 'from $1.27 / mo',
+        priceHint: 'from $1.27 /\u00a0mo',
         highlights: ['Clean IPv4 pools', 'Sticky sessions up to 60 min', 'Country & ISP targeting'],
       },
     },
@@ -111,7 +111,7 @@ const SERVICE_DEFINITIONS: ServiceDefinition[] = [
               id: 'static-basic',
               name: 'Базовый',
               price: '$1.95',
-              period: 'за прокси / мес',
+              period: 'за\u00a0прокси /\u00a0мес',
               description: 'Базовый набор для команды.',
               features: [
                 'До 3 пользователей',
@@ -126,8 +126,9 @@ const SERVICE_DEFINITIONS: ServiceDefinition[] = [
             {
               id: 'static-dedicated',
               name: 'Выделенный',
+              headline: 'Популярный',
               price: '$3.95',
-              period: 'за прокси / мес',
+              period: 'за\u00a0прокси /\u00a0мес',
               description: 'Выделенные ресурсы для стабильной работы.',
               features: [
                 'Выделенный IP на пользователя',
@@ -143,7 +144,7 @@ const SERVICE_DEFINITIONS: ServiceDefinition[] = [
               id: 'static-premium',
               name: 'Премиум',
               price: '$5.47',
-              period: 'за прокси / мес',
+              period: 'за\u00a0прокси /\u00a0мес',
               description: 'Чистые IP и максимум возможностей.',
               features: [
                 'Новые IP',
@@ -167,7 +168,7 @@ const SERVICE_DEFINITIONS: ServiceDefinition[] = [
               id: 'static-basic',
               name: 'Basic',
               price: '$1.95',
-              period: 'per proxy / mo',
+              period: 'per\u00a0proxy /\u00a0mo',
               description: 'Starter pack for small teams.',
               features: [
                 'Up to 3 users',
@@ -182,8 +183,9 @@ const SERVICE_DEFINITIONS: ServiceDefinition[] = [
             {
               id: 'static-dedicated',
               name: 'Dedicated',
+              headline: 'Popular',
               price: '$3.95',
-              period: 'per proxy / mo',
+              period: 'per\u00a0proxy /\u00a0mo',
               description: 'Dedicated resources for steady work.',
               features: [
                 'Dedicated IP for one user',
@@ -199,7 +201,7 @@ const SERVICE_DEFINITIONS: ServiceDefinition[] = [
               id: 'static-premium',
               name: 'Premium',
               price: '$5.47',
-              period: 'per proxy / mo',
+              period: 'per\u00a0proxy /\u00a0mo',
               description: 'Fresh IPs and full power.',
               features: [
                 'Fresh IPs',
@@ -224,13 +226,13 @@ const SERVICE_DEFINITIONS: ServiceDefinition[] = [
       ru: {
         title: 'Static Residential IPv6',
         headline: 'Гибкая стоимость для скейлинга',
-        priceHint: 'от $0.55 / мес',
+        priceHint: 'от $0.55 /\u00a0мес',
         highlights: ['SOCKS5 и HTTP/S', 'Sticky-сессии', 'Ротация подсетей'],
       },
       en: {
         title: 'Static Residential IPv6',
         headline: 'Flexible pricing for scale',
-        priceHint: 'from $0.55 / mo',
+        priceHint: 'from $0.55 /\u00a0mo',
         highlights: ['SOCKS5 & HTTP/S', 'Sticky sessions', 'Subnet rotation'],
       },
     },


### PR DESCRIPTION
## Summary
- add dedicated ProgressStepper, shared check icon, and numeric stepper input to support the updated order flow
- restyle the order builder to highlight selections, unify hover/focus states, and format prices per locale with tabular numerals
- introduce sticky desktop summary and mobile summary bar with locale-aware totals and quantity/period recap

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e2cd2be0f8832abb9336875db39bd3