### PR TITLE
Align pricing cards and improve auto-renew switch

### DIFF
--- a/app/pricing/page.module.css
+++ b/app/pricing/page.module.css
@@ -82,6 +82,13 @@
   border: 1px solid rgba(15, 23, 42, 0.08);
 }
 
+.planIntro {
+  min-height: 92px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
 .planHeader {
   display: flex;
   flex-direction: column;
@@ -108,17 +115,7 @@
 }
 
 .planPrice {
-  margin-top: 1.5rem;
-  font-size: 2rem;
-  font-weight: 700;
-  color: #0b1220;
-}
-
-.planUnit {
-  display: block;
-  margin-top: 0.5rem;
-  font-size: 0.95rem;
-  color: rgba(11, 18, 32, 0.6);
+  margin-top: 0.25rem;
 }
 
 .planFeatures {

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -7,6 +7,7 @@ import { buildOrderUrl, catalog, type PlanId } from '@/config/catalog';
 import KycNotice from '@/components/KycNotice';
 import PaymentsSecurity from '@/components/PaymentsSecurity';
 import Section from '@/components/layout/Section';
+import PriceLabel from '@/components/ui/PriceLabel';
 import { useI18n } from '@/lib/i18n';
 import type { Locale } from '@/lib/i18n';
 import { getOrderPage, type OrderService } from '@/lib/order';
@@ -153,7 +154,7 @@ export default function PricingPage() {
             const normalizedUnitLabel = locale === 'ru'
               ? unitLabelSource
               : unitLabelSource.replace('month', 'mo');
-            const unitLabel = localizeUnitLabel(normalizedUnitLabel, locale);
+            const unitLabel = localizeUnitLabel(normalizedUnitLabel, locale).replace(/\u00a0/g, ' ');
             const features = (localized?.features ?? plan.features).map((feature) =>
               localizeFeatureCopy(feature, locale),
             );
@@ -162,14 +163,18 @@ export default function PricingPage() {
 
             return (
               <article key={plan.id} className={styles.planCard}>
-                <div className={styles.planHeader}>
-                  <h3 className={styles.planTitle}>{plan.title}</h3>
-                  {badge ? <span className={styles.planBadge}>{badge}</span> : null}
+                <div className={styles.planIntro}>
+                  <div className={styles.planHeader}>
+                    <h3 className={styles.planTitle}>{plan.title}</h3>
+                    {badge ? <span className={styles.planBadge}>{badge}</span> : null}
+                  </div>
+                  <PriceLabel
+                    locale={locale}
+                    amount={priceValue}
+                    unit={unitLabel}
+                    className={styles.planPrice}
+                  />
                 </div>
-                <p className={styles.planPrice}>
-                  {formatUsd(priceValue)}
-                  <span className={styles.planUnit}>{unitLabel}</span>
-                </p>
                 <ul className={styles.planFeatures}>
                   {features.map((feature) => (
                     <li key={feature}>{feature}</li>
@@ -209,27 +214,28 @@ export default function PricingPage() {
 
         <div className={styles.planGrid}>
           {catalog.staticIpv6.plans.map((plan) => {
-            const hasPrice = typeof plan.priceUsd === 'number';
-            const priceLabel = hasPrice
-              ? formatUsd(plan.priceUsd ?? 0)
-              : `from ${formatUsd(ipv6FallbackFromUsd)}`;
             const unitLabelSource = plan.unit ?? 'per proxy / mo';
             const normalizedUnitLabel = locale === 'ru'
               ? unitLabelSource
               : unitLabelSource.replace('month', 'mo');
-            const unitLabel = localizeUnitLabel(normalizedUnitLabel, locale);
+            const unitLabel = localizeUnitLabel(normalizedUnitLabel, locale).replace(/\u00a0/g, ' ');
             const features = plan.features.map((feature) => localizeFeatureCopy(feature, locale));
+            const amount = plan.priceUsd ?? ipv6FallbackFromUsd;
 
             return (
               <article key={plan.id} className={styles.planCard}>
-                <div className={styles.planHeader}>
-                  <h3 className={styles.planTitle}>{plan.title}</h3>
-                  {plan.badge ? <span className={styles.planBadge}>{plan.badge}</span> : null}
+                <div className={styles.planIntro}>
+                  <div className={styles.planHeader}>
+                    <h3 className={styles.planTitle}>{plan.title}</h3>
+                    {plan.badge ? <span className={styles.planBadge}>{plan.badge}</span> : null}
+                  </div>
+                  <PriceLabel
+                    locale={locale}
+                    amount={amount}
+                    unit={unitLabel}
+                    className={styles.planPrice}
+                  />
                 </div>
-                <p className={styles.planPrice}>
-                  {priceLabel}
-                  <span className={styles.planUnit}>{unitLabel}</span>
-                </p>
                 <ul className={styles.planFeatures}>
                   {features.map((feature) => (
                     <li key={feature}>{feature}</li>

--- a/components/ui/PriceLabel.tsx
+++ b/components/ui/PriceLabel.tsx
@@ -1,0 +1,42 @@
+import { useMemo } from 'react';
+
+export default function PriceLabel({
+  locale = 'ru',
+  amount,
+  unit = 'за прокси / мес',
+  className = '',
+}: {
+  locale?: 'ru' | 'en' | string;
+  amount: number;
+  unit?: string;
+  className?: string;
+}) {
+  const formatted = useMemo(() => {
+    const nf = new Intl.NumberFormat(locale === 'ru' ? 'ru-RU' : 'en-US', {
+      style: 'currency',
+      currency: 'USD',
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(amount);
+    return formattedParts(nf, locale);
+  }, [amount, locale]);
+
+  return (
+    <div className={className}>
+      <div className="flex items-baseline gap-1 text-gray-900 [font-variant-numeric:tabular-nums]">
+        <span className="text-2xl font-semibold leading-none">{formatted.value}</span>
+        <span className="text-base font-medium leading-none">{formatted.currency}</span>
+      </div>
+      <div className="mt-1 text-sm text-gray-500 whitespace-nowrap">{unit}</div>
+    </div>
+  );
+}
+
+function formattedParts(nf: string, locale: string) {
+  if (locale === 'ru') {
+    const [value, currency] = nf.split('\u00A0');
+    return { value, currency };
+  }
+  const match = nf.match(/^([^0-9]+)(.+)$/);
+  return match ? { currency: match[1], value: match[2] } : { currency: '$', value: nf };
+}

--- a/components/ui/PriceLabel.tsx
+++ b/components/ui/PriceLabel.tsx
@@ -21,11 +21,22 @@ export default function PriceLabel({
     return formattedParts(nf, locale);
   }, [amount, locale]);
 
+  const currencyFirst = locale !== 'ru';
+
   return (
     <div className={className}>
       <div className="flex items-baseline gap-1 text-gray-900 [font-variant-numeric:tabular-nums]">
-        <span className="text-2xl font-semibold leading-none">{formatted.value}</span>
-        <span className="text-base font-medium leading-none">{formatted.currency}</span>
+        {currencyFirst ? (
+          <>
+            <span className="text-base font-medium leading-none">{formatted.currency}</span>
+            <span className="text-2xl font-semibold leading-none">{formatted.value}</span>
+          </>
+        ) : (
+          <>
+            <span className="text-2xl font-semibold leading-none">{formatted.value}</span>
+            <span className="text-base font-medium leading-none">{formatted.currency}</span>
+          </>
+        )}
       </div>
       <div className="mt-1 text-sm text-gray-500 whitespace-nowrap">{unit}</div>
     </div>

--- a/components/ui/Switch.tsx
+++ b/components/ui/Switch.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import cn from 'clsx';
+
+export default function Switch({
+  checked,
+  onChange,
+  className = '',
+  label,
+  id,
+}: {
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  className?: string;
+  label?: string;
+  id?: string;
+}) {
+  return (
+    <button
+      id={id}
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      onClick={() => onChange(!checked)}
+      className={cn(
+        'relative inline-flex h-6 w-11 items-center rounded-full border transition-colors focus:outline-none focus-visible:ring focus-visible:ring-gray-900 focus-visible:ring-offset-2',
+        checked ? 'bg-gray-900 border-gray-900' : 'bg-gray-200 border-gray-300',
+        className,
+      )}
+    >
+      <span
+        className={cn(
+          'inline-block h-5 w-5 transform rounded-full bg-white shadow transition',
+          checked ? 'translate-x-5' : 'translate-x-1',
+        )}
+      />
+    </button>
+  );
+}

--- a/tests/order-price-switch.spec.ts
+++ b/tests/order-price-switch.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+
+test('Plan prices aligned; unit does not wrap', async ({ page }) => {
+  await page.goto('/order?service=static-ipv6&lang=ru');
+  const cards = page.locator('[data-test="plan-card"]');
+  const y0 = (await cards.nth(0).locator('h3').boundingBox())!.y;
+  const y1 = (await cards.nth(1).locator('h3').boundingBox())!.y;
+  expect(Math.abs(y0 - y1)).toBeLessThan(4);
+  await expect(cards.nth(0).locator('text=за прокси / мес')).toHaveCSS('white-space', 'nowrap');
+});
+
+test('Auto-renew switch toggles and is visible', async ({ page }) => {
+  await page.goto('/order?lang=ru');
+  const sw = page.getByRole('switch', { name: /автопрод/i });
+  await expect(sw).toBeVisible();
+  const aria1 = await sw.getAttribute('aria-checked');
+  await sw.click();
+  const aria2 = await sw.getAttribute('aria-checked');
+  expect(aria1).not.toBe(aria2);
+});


### PR DESCRIPTION
## Summary
- add a reusable PriceLabel component and apply it to pricing and order plan cards so currency and units stay aligned
- replace the order auto-renew toggle with a visible, accessible switch and surface its state in the summary string
- ensure product/plan cards are keyboard selectable and add a Playwright regression test covering prices and the switch
- make the Playwright global setup skip OS dependency installation unless explicitly requested to avoid proxy-related failures

## Testing
- npx playwright test tests/order-price-switch.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e2d41caa30832a88b732bdbd5b7d22