### PR TITLE
docs: remove local language switcher from legal layout

### DIFF
--- a/components/legal/LegalPage.tsx
+++ b/components/legal/LegalPage.tsx
@@ -1,6 +1,5 @@
 'use client';
 import Section from '@/components/layout/Section';
-import LanguageSwitcher from '@/components/LanguageSwitcher';
 import Toc from './Toc';
 
 type Section = { id: string; title: string; paragraphs: string[] };
@@ -17,21 +16,19 @@ export default function LegalPage({ dict }: { dict: LegalDict }) {
   const backToTopLabel = dict.backToTopLabel ?? 'Back to top';
   return (
     <Section bg="white" containerClassName="not-prose">
-      <div className="mx-auto flex max-w-5xl flex-col gap-6" id="top">
-        <div className="flex items-center justify-between gap-4">
-          <h1 className="text-3xl font-semibold">{dict.title}</h1>
-          <LanguageSwitcher />
+      <div className="mx-auto max-w-5xl space-y-6" id="top">
+        <div>
+          <h1 className="text-3xl font-semibold mb-4">{dict.title}</h1>
+          {dict.disclaimer && (
+            <p className="mt-4 rounded-xl border border-amber-200 bg-amber-50 p-3 text-sm text-amber-700">
+              {dict.disclaimer}
+            </p>
+          )}
+
+          {dict.intro && <p className="mt-4 opacity-80">{dict.intro}</p>}
         </div>
 
-        {dict.disclaimer && (
-          <p className="rounded-xl border border-amber-200 bg-amber-50 p-3 text-sm text-amber-700">
-            {dict.disclaimer}
-          </p>
-        )}
-
-        {dict.intro && <p className="opacity-80">{dict.intro}</p>}
-
-        <div className="mt-6 grid gap-8 md:grid-cols-3">
+        <div className="grid gap-8 md:grid-cols-3">
           <article className="prose max-w-none md:col-span-2">
             {sections.map((s) => (
               <section key={s.id} id={s.id} className="scroll-mt-24">

--- a/tests/links-and-stubs.spec.ts
+++ b/tests/links-and-stubs.spec.ts
@@ -69,8 +69,11 @@ test('legal and contact/login pages render', async ({ page }) => {
 
 test('language switcher works on stubs', async ({ page }) => {
   await page.goto('/aml');
-  await page.getByRole('main').getByRole('button', { name: 'RU' }).click();
+  const header = page.getByRole('banner');
+
+  await header.getByRole('button', { name: 'RU' }).click();
   await expect(page.getByRole('heading', { level: 1, name: 'AML Политика' })).toBeVisible();
+
   await page.reload();
   await expect(page.getByRole('heading', { level: 1, name: 'AML Политика' })).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- remove the per-page language toggle from the shared legal layout
- adjust document hero spacing now that the toggle is gone

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e40476eeb8832a8b90ef2a7993a872