### PR TITLE
Set auto renewal toggle off by default

### DIFF
--- a/app/order/OrderPageContent.tsx
+++ b/app/order/OrderPageContent.tsx
@@ -487,7 +487,7 @@ export default function OrderPageContent() {
 
     return defaultMonthsValue;
   });
-  const [autoRenew, setAutoRenew] = useState(true);
+  const [autoRenew, setAutoRenew] = useState(false);
   const [activeProgressStep, setActiveProgressStep] = useState<1 | 2 | 3 | 4>(2);
 
   useEffect(() => {
@@ -505,7 +505,7 @@ export default function OrderPageContent() {
 
       return defaultMonthsValue;
     });
-    setAutoRenew(true);
+    setAutoRenew(false);
   }, [
     activeService,
     configurationOptions,


### PR DESCRIPTION
## Summary
- set the auto renewal toggle to initialize in the off position
- ensure auto renewal resets to off when configuration defaults are restored

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e415b7cc74832aa45949a322eef4c2